### PR TITLE
Add initial Sail implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Generate 2ship.o2r
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DSKIP_NETWORKING=1
         cmake --build build-cmake --config Release --target Generate2ShipOtr -j3
     - name: Upload 2ship.o2r
       uses: actions/upload-artifact@v7
@@ -173,6 +173,18 @@ jobs:
         cmake ..
         make
         sudo make install
+    - name: Install latest SDL_net
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        if [ ! -d "SDL2_net-2.2.0" ]; then
+          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
+          tar -xzf SDL2_net-2.2.0.tar.gz
+        fi
+        cd SDL2_net-2.2.0
+        ./configure
+        make -j 10
+        sudo make install
+        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
     - name: Install libzip without crypto
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -195,7 +207,7 @@ jobs:
     - name: Build 2Ship
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_REMOTE_CONTROL=1
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
         cmake --build build-cmake --config Release -j3
         (cd build-cmake && cpack -G External)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif()
 endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Windows|Linux")
-    if(NOT DEFINED BUILD_CROWD_CONTROL)
-        set(BUILD_CROWD_CONTROL OFF)
-    endif()
-endif()
-
 # Enable the Gfx debugger in LUS to use libgfxd from ZAPDTR
 set(GFX_DEBUG_DISASSEMBLER ON)
 

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -29,6 +29,7 @@
 #include "Enhancements/Trackers/TimeSplits/TimesplitsSettings.h"
 #include "BenMenu.h"
 #include "BenMenuBar.h"
+#include "DeveloperTools/ActionDebugger.h"
 #include "DeveloperTools/HookDebugger.h"
 #include "DeveloperTools/SaveEditor.h"
 #include "DeveloperTools/ActorViewer.h"
@@ -47,6 +48,7 @@ std::shared_ptr<Ship::GuiWindow> mStatsWindow;
 std::shared_ptr<Ship::GuiWindow> mGfxDebuggerWindow;
 std::shared_ptr<Ship::GuiWindow> mInputEditorWindow;
 
+std::shared_ptr<ActionDebuggerWindow> mActionDebuggerWindow;
 std::shared_ptr<HookDebuggerWindow> mHookDebuggerWindow;
 std::shared_ptr<SaveEditorWindow> mSaveEditorWindow;
 std::shared_ptr<HudEditorWindow> mHudEditorWindow;
@@ -111,6 +113,10 @@ void SetupGuiElements() {
     if (mInputEditorWindow == nullptr) {
         SPDLOG_ERROR("Could not find input editor window");
     }
+
+    mActionDebuggerWindow =
+        std::make_shared<ActionDebuggerWindow>("gWindows.ActionDebugger", "Action Debugger", ImVec2(560, 680));
+    gui->AddGuiWindow(mActionDebuggerWindow);
 
     mHookDebuggerWindow =
         std::make_shared<HookDebuggerWindow>("gWindows.HookDebugger", "Hook Debugger", ImVec2(480, 600));
@@ -201,6 +207,7 @@ void Destroy() {
     mRandoCheckTrackerWindow = nullptr;
     mRandoCheckTrackerSettingsWindow = nullptr;
 
+    mActionDebuggerWindow = nullptr;
     mHookDebuggerWindow = nullptr;
     mSaveEditorWindow = nullptr;
     mHudEditorWindow = nullptr;

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -2197,6 +2197,14 @@ void BenMenu::AddDevTools() {
             "Enables the Gfx Debugger window, allowing you to input commands, type help for some examples."))
         .WindowName("Gfx Debugger");
 
+    path = { "Dev Tools", "Action Debugger", SECTION_COLUMN_1 };
+    AddSidebarEntry("Dev Tools", "Action Debugger", 1);
+    AddWidget(path, "Popout Action Debugger", WIDGET_WINDOW_BUTTON)
+        .CVar("gWindows.ActionDebugger")
+        .Options(ButtonOptions().Tooltip("Enables the Action Debugger window, for firing any registered "
+                                         "GameInteractor action and watching the queue handle it."))
+        .WindowName("Action Debugger");
+
     path = { "Dev Tools", "Hook Debugger", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Hook Debugger", 1);
     AddWidget(path, "Popout Hook Debugger", WIDGET_WINDOW_BUTTON)

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -622,7 +622,7 @@ void Menu::DrawElement() {
     for (auto& label : menuOrder) {
         ImVec2 size = ImGui::CalcTextSize(label.c_str());
         headerSizes.push_back(size);
-        headerWidth += size.x + style.FramePadding.x * 2;
+        headerWidth += size.x + style.FramePadding.x * 2 + style.ItemSpacing.x;
         if (label == headerIndex) {
             headerWidth += style.ItemSpacing.x;
         }

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -42,10 +42,7 @@
 // #include <functions.h>
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
-#ifdef ENABLE_CROWD_CONTROL
-#include "Enhancements/crowd-control/CrowdControl.h"
-CrowdControl* CrowdControl::Instance;
-#endif
+#include "2s2h/Network/Sail/Sail.h"
 
 #include <libultraship/libultraship.h>
 #include <libultraship/controller/controldeck/ControlDeck.h>
@@ -119,6 +116,7 @@ CrowdControl* CrowdControl::Instance;
 OTRGlobals* OTRGlobals::Instance;
 GameInteractor* GameInteractor::Instance;
 AudioCollection* AudioCollection::Instance;
+Sail* Sail::Instance;
 
 extern "C" char** cameraStrings;
 bool prevAltAssets = false;
@@ -972,6 +970,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
 
     GameInteractor::Instance = new GameInteractor();
     AudioCollection::Instance = new AudioCollection();
+    Sail::Instance = new Sail();
     LoadGuiTextures();
     ModMenu_LoadArchives();
     BenGui::SetupGuiElements();
@@ -1002,15 +1001,10 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     }
 
     srand(now);
-#ifdef ENABLE_CROWD_CONTROL
-    CrowdControl::Instance = new CrowdControl();
-    CrowdControl::Instance->Init();
-    if (CVarGetInteger("gCrowdControl", 0)) {
-        CrowdControl::Instance->Enable();
-    } else {
-        CrowdControl::Instance->Disable();
+    SDLNet_Init();
+    if (CVarGetInteger("gNetwork.Sail.Enabled", 0)) {
+        Sail::Instance->Enable();
     }
-#endif
 
     Ship::Context::GetRawInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetRawInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
@@ -1023,10 +1017,9 @@ extern "C" void SaveManager_ThreadPoolWait() {
 extern "C" void DeinitOTR() {
     SaveManager_ThreadPoolWait();
     OTRAudio_Exit();
-#ifdef ENABLE_CROWD_CONTROL
-    CrowdControl::Instance->Disable();
-    CrowdControl::Instance->Shutdown();
-#endif
+    GameInteractor::Instance->CancelAllActions();
+    Sail::Instance->Disable();
+    SDLNet_Quit();
 
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before
     // these shared ptrs.

--- a/mm/2s2h/DeveloperTools/ActionDebugger.cpp
+++ b/mm/2s2h/DeveloperTools/ActionDebugger.cpp
@@ -1,0 +1,437 @@
+#include "ActionDebugger.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
+#include "2s2h/BenGui/UIWidgets.hpp"
+#include <libultraship/bridge/consolevariablebridge.h>
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+extern "C" {
+#include "variables.h"
+}
+
+namespace {
+
+const ImVec4& Color(UIWidgets::Colors color) {
+    return UIWidgets::ColorValues.at(color);
+}
+
+// Wrapped, because these are long enough to clip.
+void Hint(const char* text) {
+    ImGui::PushStyleColor(ImGuiCol_Text, Color(UIWidgets::Colors::Gray));
+    ImGui::TextWrapped("%s", text);
+    ImGui::PopStyleColor();
+}
+
+struct ActionEditor {
+    std::unordered_map<std::string, bool> bools;
+    std::unordered_map<std::string, int> ints;
+    std::unordered_map<std::string, float> floats;
+    std::unordered_map<std::string, std::string> strings;
+    int duration = 0;
+    std::string lastError;
+    bool seeded = false;
+};
+
+std::unordered_map<int, ActionEditor> editors;
+
+bool queueAsSession = false;
+int expiresAfter = 0;
+
+UIWidgets::Colors ValenceColor(GIValence valence) {
+    switch (valence) {
+        case GI_VALENCE_POSITIVE:
+            return UIWidgets::Colors::Green;
+        case GI_VALENCE_NEGATIVE:
+            return UIWidgets::Colors::Red;
+        case GI_VALENCE_NEUTRAL:
+            break;
+    }
+    return UIWidgets::Colors::LightBlue;
+}
+
+const char* ActionName(GIActionId id) {
+    if (id == GI_ACTION_NONE) {
+        return "(anonymous)";
+    }
+    const GIActions::Definition* definition = GIActions::Get(id);
+    return definition != nullptr ? definition->name : "(unknown)";
+}
+
+template <typename T> T DefaultOr(const GIParamSpec& spec, T fallback) {
+    if (spec.defaultValue.has_value()) {
+        if (const T* value = std::get_if<T>(&*spec.defaultValue)) {
+            return *value;
+        }
+    }
+    return fallback;
+}
+
+void SeedEditor(ActionEditor& editor, const GIActions::Definition& definition) {
+    for (const auto& spec : definition.schema) {
+        switch (spec.type) {
+            case GI_PARAM_BOOL:
+                editor.bools[spec.name] = DefaultOr<bool>(spec, false);
+                break;
+            case GI_PARAM_INT:
+                editor.ints[spec.name] = DefaultOr<int32_t>(spec, 0);
+                break;
+            case GI_PARAM_FLOAT:
+                editor.floats[spec.name] = DefaultOr<float>(spec, 0.0f);
+                break;
+            case GI_PARAM_STRING:
+                editor.strings[spec.name] = DefaultOr<std::string>(spec, "");
+                break;
+        }
+    }
+    editor.duration = (int)definition.defaultDuration;
+    editor.seeded = true;
+}
+
+void DrawProgress(const GIAction& action) {
+    float progress = action.duration > 0 ? (float)action.elapsed / (float)action.duration : 0.0f;
+    char overlay[32];
+    snprintf(overlay, sizeof(overlay), "%u / %u", action.elapsed, action.duration);
+    ImGui::ProgressBar(progress, ImVec2(-FLT_MIN, 0), overlay);
+}
+
+void DrawParamEditors(ActionEditor& editor, const GIActions::Definition& definition) {
+    for (const auto& spec : definition.schema) {
+        std::string id = "##" + std::string(definition.name) + spec.name;
+
+        if (spec.type == GI_PARAM_BOOL) {
+            UIWidgets::Checkbox((std::string(spec.name) + id).c_str(), &editor.bools[spec.name],
+                                { .color = UIWidgets::Colors::Gray });
+            continue;
+        }
+
+        ImGui::Text("%s", spec.name);
+        if (spec.required) {
+            ImGui::SameLine(0.0f, 2.0f);
+            ImGui::TextColored(Color(UIWidgets::Colors::Red), "*");
+        }
+        if (spec.min.has_value() || spec.max.has_value()) {
+            ImGui::SameLine();
+            if (spec.min.has_value() && spec.max.has_value()) {
+                ImGui::TextColored(Color(UIWidgets::Colors::Gray), "(%g .. %g)", *spec.min, *spec.max);
+            } else if (spec.min.has_value()) {
+                ImGui::TextColored(Color(UIWidgets::Colors::Gray), "(>= %g)", *spec.min);
+            } else {
+                ImGui::TextColored(Color(UIWidgets::Colors::Gray), "(<= %g)", *spec.max);
+            }
+        }
+
+        switch (spec.type) {
+            case GI_PARAM_INT:
+                UIWidgets::PushStyleInput(UIWidgets::Colors::Gray);
+                ImGui::InputInt(id.c_str(), &editor.ints[spec.name]);
+                UIWidgets::PopStyleInput();
+                break;
+            case GI_PARAM_FLOAT:
+                UIWidgets::PushStyleInput(UIWidgets::Colors::Gray);
+                ImGui::InputFloat(id.c_str(), &editor.floats[spec.name]);
+                UIWidgets::PopStyleInput();
+                break;
+            case GI_PARAM_STRING:
+                UIWidgets::InputString(id.c_str(), &editor.strings[spec.name],
+                                       { .labelPosition = UIWidgets::LabelPosition::None });
+                break;
+            case GI_PARAM_BOOL:
+                break;
+        }
+    }
+}
+
+void FireAction(ActionEditor& editor, const GIActions::Definition& definition) {
+    GIParams params;
+    for (const auto& spec : definition.schema) {
+        switch (spec.type) {
+            case GI_PARAM_BOOL:
+                params.Set(spec.name, editor.bools[spec.name]);
+                break;
+            case GI_PARAM_INT:
+                params.Set(spec.name, (int32_t)editor.ints[spec.name]);
+                break;
+            case GI_PARAM_FLOAT:
+                params.Set(spec.name, editor.floats[spec.name]);
+                break;
+            case GI_PARAM_STRING:
+                params.Set(spec.name, editor.strings[spec.name]);
+                break;
+        }
+    }
+
+    std::string error;
+    auto action = definition.Build(std::move(params), &error);
+    if (!action.has_value()) {
+        editor.lastError = error;
+        return;
+    }
+    editor.lastError.clear();
+
+    if (editor.duration > 0) {
+        action->duration = (uint32_t)editor.duration;
+    }
+    action->lifetime = queueAsSession ? GI_LIFETIME_SESSION : GI_LIFETIME_SAVE;
+    action->expiresAfter = (uint32_t)std::max(expiresAfter, 0);
+
+    GameInteractor::Instance->Queue(std::move(*action));
+}
+
+const std::vector<const GIActions::Definition*>& SortedActions() {
+    static std::vector<const GIActions::Definition*> sorted = [] {
+        std::vector<const GIActions::Definition*> all;
+        all.reserve(GIActions::All().size());
+        for (const auto& definition : GIActions::All()) {
+            all.push_back(&definition);
+        }
+        std::sort(all.begin(), all.end(), [](const GIActions::Definition* a, const GIActions::Definition* b) {
+            return strcmp(a->displayName, b->displayName) < 0;
+        });
+        return all;
+    }();
+    return sorted;
+}
+
+void DrawStatusBar() {
+    ImGui::Text("Gate");
+    ImGui::SameLine();
+    if (GameInteractor::Instance->CanProcessActions() == GI_AVAILABILITY_READY) {
+        ImGui::TextColored(Color(UIWidgets::Colors::Green), "READY");
+    } else {
+        ImGui::TextColored(Color(UIWidgets::Colors::Yellow), "WAITING");
+        UIWidgets::Tooltip("A message, a cutscene, or death is up. Requests will wait rather than be dropped.");
+    }
+
+    ImGui::SameLine();
+    ImGui::TextColored(Color(UIWidgets::Colors::DarkGray), "|");
+    ImGui::SameLine();
+    ImGui::Text("Blocking");
+    ImGui::SameLine();
+    const GIAction* blocking = GameInteractor::Instance->BlockingAction();
+    if (blocking != nullptr) {
+        ImGui::TextColored(Color(UIWidgets::Colors::Yellow), "%s", ActionName(blocking->id));
+    } else {
+        ImGui::TextColored(Color(UIWidgets::Colors::Gray), "none");
+    }
+
+    ImGui::SameLine();
+    ImGui::TextColored(Color(UIWidgets::Colors::DarkGray), "|");
+    ImGui::SameLine();
+    ImGui::Text("Pending");
+    ImGui::SameLine();
+    ImGui::TextColored(Color(UIWidgets::Colors::Gray), "%zu", GameInteractor::Instance->PendingActions().size());
+    ImGui::SameLine();
+    ImGui::TextColored(Color(UIWidgets::Colors::DarkGray), "|");
+    ImGui::SameLine();
+    ImGui::Text("Active");
+    ImGui::SameLine();
+    ImGui::TextColored(Color(UIWidgets::Colors::Gray), "%zu", GameInteractor::Instance->ActiveActions().size());
+}
+
+void DrawActionCard(const GIActions::Definition& definition) {
+    ActionEditor& editor = editors[definition.id];
+    if (!editor.seeded) {
+        SeedEditor(editor, definition);
+    }
+
+    UIWidgets::BeginCard(definition.name);
+
+    ImGui::Text("%s", definition.displayName);
+    UIWidgets::Tooltip(definition.name);
+    ImGui::SameLine(0.0f, 4.0f);
+    ImGui::TextColored(Color(UIWidgets::Colors::Gray), "(%s)", definition.IsTimed() ? "timed" : "instant");
+
+    const GIAction* active = GameInteractor::Instance->FindActive(definition.id);
+    if (active != nullptr) {
+        DrawProgress(*active);
+    }
+
+    if (!definition.schema.empty() || definition.IsTimed()) {
+        UIWidgets::Separator(true, true);
+        DrawParamEditors(editor, definition);
+
+        if (definition.IsTimed()) {
+            ImGui::Text("duration");
+            ImGui::SameLine();
+            ImGui::TextColored(Color(UIWidgets::Colors::Gray), "(frames, default %u)", definition.defaultDuration);
+            UIWidgets::PushStyleInput(UIWidgets::Colors::Gray);
+            ImGui::InputInt(("##duration" + std::string(definition.name)).c_str(), &editor.duration);
+            UIWidgets::PopStyleInput();
+        }
+    }
+
+    UIWidgets::Spacer(2.0f);
+
+    std::string fireLabel = "Fire##" + std::string(definition.name);
+    if (definition.IsTimed()) {
+        float half = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x) / 2.0f;
+        if (UIWidgets::Button(fireLabel.c_str(),
+                              { .size = ImVec2(half, 0), .color = ValenceColor(definition.valence) })) {
+            FireAction(editor, definition);
+        }
+        ImGui::SameLine();
+        ImGui::BeginDisabled(active == nullptr);
+        if (UIWidgets::Button(("Cancel##" + std::string(definition.name)).c_str(),
+                              { .size = ImVec2(half, 0), .color = UIWidgets::Colors::Gray })) {
+            GameInteractor::Instance->CancelAction(definition.id);
+        }
+        ImGui::EndDisabled();
+    } else if (UIWidgets::Button(fireLabel.c_str(),
+                                 { .size = UIWidgets::Sizes::Fill, .color = ValenceColor(definition.valence) })) {
+        FireAction(editor, definition);
+    }
+
+    if (!editor.lastError.empty()) {
+        ImGui::TextColored(Color(UIWidgets::Colors::Red), "%s", editor.lastError.c_str());
+    }
+
+    UIWidgets::EndCard();
+}
+
+void DrawActionsTab() {
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 3.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 8.0f));
+    ImGui::BeginChild("actionsTab", ImVec2(0, 0), true);
+
+    UIWidgets::Checkbox("Queue as session lifetime", &queueAsSession, { .color = UIWidgets::Colors::Gray });
+    UIWidgets::Tooltip("Session requests survive loading a different save, the way Sail's and CrowdControl's do. "
+                       "Save-scoped ones are dropped on save load.");
+
+    ImGui::Text("Expires after");
+    ImGui::SameLine();
+    ImGui::TextColored(Color(UIWidgets::Colors::Gray), "(frames, 0 = wait forever)");
+    UIWidgets::PushStyleInput(UIWidgets::Colors::Gray);
+    ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);
+    ImGui::InputInt("##expiresAfter", &expiresAfter);
+    UIWidgets::PopStyleInput();
+    UIWidgets::Tooltip("How long an action waits for the gate to open before giving up and reporting EXPIRED. "
+                       "Set this, then fire something during a cutscene.");
+
+    UIWidgets::Separator();
+
+    UIWidgets::BeginCardLayout({ .columnsPerRow = 2, .minColumnWidth = 220.0f });
+    for (const GIActions::Definition* definition : SortedActions()) {
+        DrawActionCard(*definition);
+    }
+    UIWidgets::EndCardLayout();
+
+    ImGui::EndChild();
+    ImGui::PopStyleVar(2);
+}
+
+void DrawQueueTab() {
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 3.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 8.0f));
+    ImGui::BeginChild("queueTab", ImVec2(0, 0), true);
+
+    UIWidgets::BeginCardLayout({ .columnsPerRow = 1 });
+
+    UIWidgets::BeginCard("pendingCard");
+    const auto& pending = GameInteractor::Instance->PendingActions();
+    ImGui::Text("Pending (%zu)", pending.size());
+    Hint("Queued, not started. An action that isn't ready keeps its place while ready ones go ahead.");
+    if (pending.empty()) {
+        UIWidgets::Spacer(2.0f);
+        ImGui::TextColored(Color(UIWidgets::Colors::Gray), "Nothing queued.");
+    } else if (ImGui::BeginTable("##pending", 4,
+                                 ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp)) {
+        ImGui::TableSetupColumn("Action");
+        ImGui::TableSetupColumn("Waiting");
+        ImGui::TableSetupColumn("Lifetime");
+        ImGui::TableSetupColumn("Expires");
+        ImGui::TableHeadersRow();
+        for (const auto& action : pending) {
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", ActionName(action.id));
+            ImGui::TableNextColumn();
+            if (action.framesWaiting > 0) {
+                ImGui::TextColored(Color(UIWidgets::Colors::Yellow), "%u frames", action.framesWaiting);
+            } else {
+                ImGui::TextColored(Color(UIWidgets::Colors::Gray), "-");
+            }
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", action.lifetime == GI_LIFETIME_SESSION ? "session" : "save");
+            ImGui::TableNextColumn();
+            if (action.expiresAfter > 0) {
+                ImGui::Text("%u", action.expiresAfter);
+            } else {
+                ImGui::TextColored(Color(UIWidgets::Colors::Gray), "never");
+            }
+        }
+        ImGui::EndTable();
+    }
+    UIWidgets::EndCard();
+
+    UIWidgets::BeginCard("activeCard");
+    const auto& active = GameInteractor::Instance->ActiveActions();
+    ImGui::Text("Active (%zu)", active.size());
+    Hint("Timed actions ticking now. These don't block the queue.");
+
+    std::optional<GIActionId> toCancel = std::nullopt;
+    if (active.empty()) {
+        UIWidgets::Spacer(2.0f);
+        ImGui::TextColored(Color(UIWidgets::Colors::Gray), "Nothing running.");
+    } else if (ImGui::BeginTable("##active", 3,
+                                 ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp)) {
+        ImGui::TableSetupColumn("Action");
+        ImGui::TableSetupColumn("Progress");
+        ImGui::TableSetupColumn("##cancel", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableHeadersRow();
+        for (const auto& action : active) {
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", ActionName(action.id));
+            ImGui::TableNextColumn();
+            DrawProgress(action);
+            ImGui::TableNextColumn();
+            ImGui::PushID((int)action.id);
+            if (UIWidgets::Button("Cancel", { .size = UIWidgets::Sizes::Inline, .color = UIWidgets::Colors::Gray })) {
+                toCancel = action.id;
+            }
+            ImGui::PopID();
+        }
+        ImGui::EndTable();
+    }
+    UIWidgets::EndCard();
+
+    UIWidgets::EndCardLayout();
+
+    if (toCancel.has_value()) {
+        GameInteractor::Instance->CancelAction(*toCancel);
+    }
+
+    ImGui::EndChild();
+    ImGui::PopStyleVar(2);
+}
+
+} // namespace
+
+void ActionDebuggerWindow::DrawElement() {
+    if (gPlayState == NULL) {
+        ImGui::TextColored(Color(UIWidgets::Colors::Yellow),
+                           "Not in game -- actions can only be queued during gameplay.");
+        return;
+    }
+
+    DrawStatusBar();
+
+    UIWidgets::PushStyleTabs(UIWidgets::Colors(CVarGetInteger("gSettings.Menu.Theme", 5)));
+    if (ImGui::BeginTabBar("ActionDebuggerTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {
+        if (ImGui::BeginTabItem("Actions")) {
+            DrawActionsTab();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Queue")) {
+            DrawQueueTab();
+            ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
+    }
+    UIWidgets::PopStyleTabs();
+}

--- a/mm/2s2h/DeveloperTools/ActionDebugger.h
+++ b/mm/2s2h/DeveloperTools/ActionDebugger.h
@@ -1,0 +1,15 @@
+#ifndef ACTION_DEBUGGER_H
+#define ACTION_DEBUGGER_H
+
+#include <ship/window/gui/GuiWindow.h>
+
+class ActionDebuggerWindow : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override{};
+    void DrawElement() override;
+    void UpdateElement() override{};
+};
+
+#endif // ACTION_DEBUGGER_H

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -8,6 +8,7 @@
 #include "2s2h/BenGui/Notification.h"
 #include "2s2h/Rando/Spoiler/Spoiler.h"
 #include "2s2h/ShipUtils.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 #include "interface/icon_item_dungeon_static/icon_item_dungeon_static.h"
 #include "archives/icon_item_24_static/icon_item_24_static_yar.h"
@@ -994,52 +995,52 @@ void DrawItemsAndMasksTab() {
             std::string buttonLabel = "Give ";
             buttonLabel += randoStaticItem.name;
             if (UIWidgets::Button(buttonLabel.c_str())) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                    .showGetItemCutscene =
-                        Rando::StaticData::ShouldShowGetItemCutscene(Rando::ConvertItem(randoItemId)),
-                    .param = (int16_t)randoItemId,
-                    .giveItem =
-                        [](Actor* actor, PlayState* play) {
-                            RandoItemId randoItemId = Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM);
-                            std::string prefix = "You found";
-                            std::string message = Rando::StaticData::GetItemName(randoItemId);
+                GameInteractor::Instance->Queue(GIActions::GiveItem(
+                    { .showGetItemCutscene =
+                          Rando::StaticData::ShouldShowGetItemCutscene(Rando::ConvertItem(randoItemId)),
+                      .param = (int16_t)randoItemId,
+                      .giveItem =
+                          [](Actor* actor, PlayState* play) {
+                              RandoItemId randoItemId = Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM);
+                              std::string prefix = "You found";
+                              std::string message = Rando::StaticData::GetItemName(randoItemId);
 
-                            CustomMessage::Entry entry = {
-                                .textboxType = 2,
-                                .icon = Rando::StaticData::GetIconForZMessage(randoItemId),
-                                .msg = prefix + " " + message + "!",
-                            };
+                              CustomMessage::Entry entry = {
+                                  .textboxType = 2,
+                                  .icon = Rando::StaticData::GetIconForZMessage(randoItemId),
+                                  .msg = prefix + " " + message + "!",
+                              };
 
-                            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                CustomMessage::SetActiveCustomMessage(entry.msg, entry);
-                            } else if (Rando::StaticData::ShouldShowGetItemCutscene(
-                                           Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM))) {
-                                CustomMessage::StartTextbox(entry.msg + "\x1C\x02\x10", entry);
-                            } else {
-                                Notification::Emit({
-                                    .itemIcon = Rando::StaticData::GetIconTexturePath(randoItemId),
-                                    .message = prefix,
-                                    .suffix = message,
-                                });
-                            }
-                            Rando::GiveItem(randoItemId);
-                            CUSTOM_ITEM_PARAM = randoItemId;
-                        },
-                    .drawItem =
-                        [](Actor* actor, PlayState* play) {
-                            RandoItemId randoItemId;
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                  CustomMessage::SetActiveCustomMessage(entry.msg, entry);
+                              } else if (Rando::StaticData::ShouldShowGetItemCutscene(
+                                             Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM))) {
+                                  CustomMessage::StartTextbox(entry.msg + "\x1C\x02\x10", entry);
+                              } else {
+                                  Notification::Emit({
+                                      .itemIcon = Rando::StaticData::GetIconTexturePath(randoItemId),
+                                      .message = prefix,
+                                      .suffix = message,
+                                  });
+                              }
+                              Rando::GiveItem(randoItemId);
+                              CUSTOM_ITEM_PARAM = randoItemId;
+                          },
+                      .drawItem =
+                          [](Actor* actor, PlayState* play) {
+                              RandoItemId randoItemId;
 
-                            // If the item has been given, the CUSTOM_ITEM_PARAM is set to the RI, prior to that it's
-                            // the RC
-                            if (CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION) {
-                                randoItemId = (RandoItemId)CUSTOM_ITEM_PARAM;
-                            } else {
-                                randoItemId = Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM);
-                            }
+                              // If the item has been given, the CUSTOM_ITEM_PARAM is set to the RI, prior to that it's
+                              // the RC
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION) {
+                                  randoItemId = (RandoItemId)CUSTOM_ITEM_PARAM;
+                              } else {
+                                  randoItemId = Rando::ConvertItem((RandoItemId)CUSTOM_ITEM_PARAM);
+                              }
 
-                            Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            Rando::DrawItem(randoItemId, RC_UNKNOWN, actor);
-                        } });
+                              Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                              Rando::DrawItem(randoItemId, RC_UNKNOWN, actor);
+                          } }));
             }
         }
     }

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipCouplesMaskCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipCouplesMaskCutscene.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_En_An/z_en_an.h"
@@ -36,7 +37,7 @@ static void SkipHandleCouplesMaskCs(EnTest3* kafei) {
     kafei->player.yaw = ROTATION.y;
 
     if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_COUPLE)) {
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        GameInteractor::Instance->Queue(GIActions::GiveItem({
             .showGetItemCutscene = true,
             .param = GID_MASK_COUPLE,
             .giveItem =
@@ -50,7 +51,7 @@ static void SkipHandleCouplesMaskCs(EnTest3* kafei) {
 
                     Item_Give(play, ITEM_MASK_COUPLE);
                 },
-        });
+        }));
     }
 
     anju->actor.textId = NOTEBOOK_EVENTS_TEXT_ID;

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGreatFairyCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGreatFairyCutscene.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -42,106 +43,106 @@ void RegisterSkipGreatFairyCutscene() {
                 switch (elfgrp->type) {
                     case ENELFGRP_TYPE_POWER:
                         if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK)) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                                .showGetItemCutscene = true,
-                                .param = GID_SWORD_KOKIRI,
-                                .giveItem = [](Actor* actor, PlayState* play) {
-                                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                        CustomMessage::SetActiveCustomMessage("You received the Great Spin Attack!",
-                                                                              { .textboxType = 2 });
-                                    } else {
-                                        CustomMessage::StartTextbox("You received the Great Spin Attack!\x1C\x02\x10",
-                                                                    { .textboxType = 2 });
-                                    }
-                                    SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK);
-                                } });
+                            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                                { .showGetItemCutscene = true,
+                                  .param = GID_SWORD_KOKIRI,
+                                  .giveItem = [](Actor* actor, PlayState* play) {
+                                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                          CustomMessage::SetActiveCustomMessage("You received the Great Spin Attack!",
+                                                                                { .textboxType = 2 });
+                                      } else {
+                                          CustomMessage::StartTextbox("You received the Great Spin Attack!\x1C\x02\x10",
+                                                                      { .textboxType = 2 });
+                                      }
+                                      SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK);
+                                  } }));
                         }
                         break;
                     case ENELFGRP_TYPE_WISDOM:
                         if (!gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                                .showGetItemCutscene = true,
-                                .param = GID_MAGIC_JAR_BIG,
-                                .giveItem = [](Actor* actor, PlayState* play) {
-                                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                        CustomMessage::SetActiveCustomMessage("You received Double Magic!",
-                                                                              { .textboxType = 2 });
-                                    } else {
-                                        CustomMessage::StartTextbox("You received Double Magic!\x1C\x02\x10",
-                                                                    { .textboxType = 2 });
-                                    }
-                                    gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = true;
-                                    gSaveContext.magicFillTarget = MAGIC_DOUBLE_METER;
-                                    gSaveContext.save.saveInfo.playerData.magicLevel = 0;
-                                } });
+                            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                                { .showGetItemCutscene = true,
+                                  .param = GID_MAGIC_JAR_BIG,
+                                  .giveItem = [](Actor* actor, PlayState* play) {
+                                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                          CustomMessage::SetActiveCustomMessage("You received Double Magic!",
+                                                                                { .textboxType = 2 });
+                                      } else {
+                                          CustomMessage::StartTextbox("You received Double Magic!\x1C\x02\x10",
+                                                                      { .textboxType = 2 });
+                                      }
+                                      gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = true;
+                                      gSaveContext.magicFillTarget = MAGIC_DOUBLE_METER;
+                                      gSaveContext.save.saveInfo.playerData.magicLevel = 0;
+                                  } }));
                         }
                         break;
                     case ENELFGRP_TYPE_COURAGE:
                         if (!gSaveContext.save.saveInfo.playerData.doubleDefense) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                                .showGetItemCutscene = true,
-                                .param = GID_HEART_CONTAINER,
-                                .giveItem = [](Actor* actor, PlayState* play) {
-                                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                        CustomMessage::SetActiveCustomMessage("You received Double Defense!",
-                                                                              { .textboxType = 2 });
-                                    } else {
-                                        CustomMessage::StartTextbox("You received Double Defense!\x1C\x02\x10",
-                                                                    { .textboxType = 2 });
-                                    }
-                                    gSaveContext.save.saveInfo.playerData.doubleDefense = true;
-                                    gSaveContext.save.saveInfo.inventory.defenseHearts = 20;
-                                } });
+                            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                                { .showGetItemCutscene = true,
+                                  .param = GID_HEART_CONTAINER,
+                                  .giveItem = [](Actor* actor, PlayState* play) {
+                                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                          CustomMessage::SetActiveCustomMessage("You received Double Defense!",
+                                                                                { .textboxType = 2 });
+                                      } else {
+                                          CustomMessage::StartTextbox("You received Double Defense!\x1C\x02\x10",
+                                                                      { .textboxType = 2 });
+                                      }
+                                      gSaveContext.save.saveInfo.playerData.doubleDefense = true;
+                                      gSaveContext.save.saveInfo.inventory.defenseHearts = 20;
+                                  } }));
                         }
                         break;
                     case ENELFGRP_TYPE_KINDNESS:
                         if (INV_CONTENT(ITEM_SWORD_GREAT_FAIRY) != ITEM_SWORD_GREAT_FAIRY) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                                .showGetItemCutscene = true,
-                                .param = GID_SWORD_GREAT_FAIRY,
-                                .giveItem = [](Actor* actor, PlayState* play) {
-                                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                        CustomMessage::SetActiveCustomMessage("You received the Great Fairy Sword!",
-                                                                              { .textboxType = 2 });
-                                    } else {
-                                        CustomMessage::StartTextbox("You received the Great Fairy Sword!\x1C\x02\x10",
-                                                                    { .textboxType = 2 });
-                                    }
-                                    Item_Give(gPlayState, ITEM_SWORD_GREAT_FAIRY);
-                                } });
+                            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                                { .showGetItemCutscene = true,
+                                  .param = GID_SWORD_GREAT_FAIRY,
+                                  .giveItem = [](Actor* actor, PlayState* play) {
+                                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                          CustomMessage::SetActiveCustomMessage("You received the Great Fairy Sword!",
+                                                                                { .textboxType = 2 });
+                                      } else {
+                                          CustomMessage::StartTextbox("You received the Great Fairy Sword!\x1C\x02\x10",
+                                                                      { .textboxType = 2 });
+                                      }
+                                      Item_Give(gPlayState, ITEM_SWORD_GREAT_FAIRY);
+                                  } }));
                         }
                         break;
                     default: // ENELFGRP_TYPE_MAGIC
                         if (!gSaveContext.save.saveInfo.playerData.isMagicAcquired) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                                .showGetItemCutscene = true,
-                                .param = GID_MAGIC_JAR_SMALL,
-                                .giveItem = [](Actor* actor, PlayState* play) {
-                                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                        CustomMessage::SetActiveCustomMessage("You received the Power of Magic!",
-                                                                              { .textboxType = 2 });
-                                    } else {
-                                        CustomMessage::StartTextbox("You received the Power of Magic!\x1C\x02\x10",
-                                                                    { .textboxType = 2 });
-                                    }
-                                    gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
-                                    gSaveContext.magicFillTarget = MAGIC_NORMAL_METER;
-                                } });
+                            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                                { .showGetItemCutscene = true,
+                                  .param = GID_MAGIC_JAR_SMALL,
+                                  .giveItem = [](Actor* actor, PlayState* play) {
+                                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                          CustomMessage::SetActiveCustomMessage("You received the Power of Magic!",
+                                                                                { .textboxType = 2 });
+                                      } else {
+                                          CustomMessage::StartTextbox("You received the Power of Magic!\x1C\x02\x10",
+                                                                      { .textboxType = 2 });
+                                      }
+                                      gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
+                                      gSaveContext.magicFillTarget = MAGIC_NORMAL_METER;
+                                  } }));
                         } else if (INV_CONTENT(ITEM_MASK_DEKU) == ITEM_MASK_DEKU &&
                                    INV_CONTENT(ITEM_MASK_GREAT_FAIRY) != ITEM_MASK_GREAT_FAIRY) {
-                            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                                .showGetItemCutscene = true,
-                                .param = GID_MASK_GREAT_FAIRY,
-                                .giveItem = [](Actor* actor, PlayState* play) {
-                                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                        CustomMessage::SetActiveCustomMessage("You received the Great Fairy's Mask!",
-                                                                              { .textboxType = 2 });
-                                    } else {
-                                        CustomMessage::StartTextbox("You received the Great Fairy's Mask!\x1C\x02\x10",
-                                                                    { .textboxType = 2 });
-                                    }
-                                    Item_Give(gPlayState, ITEM_MASK_GREAT_FAIRY);
-                                } });
+                            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                                { .showGetItemCutscene = true,
+                                  .param = GID_MASK_GREAT_FAIRY,
+                                  .giveItem = [](Actor* actor, PlayState* play) {
+                                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                          CustomMessage::SetActiveCustomMessage("You received the Great Fairy's Mask!",
+                                                                                { .textboxType = 2 });
+                                      } else {
+                                          CustomMessage::StartTextbox(
+                                              "You received the Great Fairy's Mask!\x1C\x02\x10", { .textboxType = 2 });
+                                      }
+                                      Item_Give(gPlayState, ITEM_MASK_GREAT_FAIRY);
+                                  } }));
                         }
                         break;
                 }

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "functions.h"
@@ -32,19 +33,19 @@ void RegisterSkipKafeiReveal() {
         Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_PENDANT_OF_MEMORIES);
 
         if (GameInteractor_Should(VB_GIVE_PENDANT_OF_MEMORIES_FROM_KAFEI, true)) {
-            GameInteractor::Instance->events.emplace_back(
-                GIEventGiveItem{ .showGetItemCutscene = true,
-                                 .param = GID_PENDANT_OF_MEMORIES,
-                                 .giveItem = [](Actor* actor, PlayState* play) {
-                                     if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                         CustomMessage::SetActiveCustomMessage("You received the Pendant of Memories!",
-                                                                               { .textboxType = 2 });
-                                     } else {
-                                         CustomMessage::StartTextbox(
-                                             "You received the Pendant of Memories!\x1C\x02\x10", { .textboxType = 2 });
-                                     }
-                                     Item_Give(play, ITEM_PENDANT_OF_MEMORIES);
-                                 } });
+            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                { .showGetItemCutscene = true,
+                  .param = GID_PENDANT_OF_MEMORIES,
+                  .giveItem = [](Actor* actor, PlayState* play) {
+                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                          CustomMessage::SetActiveCustomMessage("You received the Pendant of Memories!",
+                                                                { .textboxType = 2 });
+                      } else {
+                          CustomMessage::StartTextbox("You received the Pendant of Memories!\x1C\x02\x10",
+                                                      { .textboxType = 2 });
+                      }
+                      Item_Give(play, ITEM_PENDANT_OF_MEMORIES);
+                  } }));
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipRosaSistersDance.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipRosaSistersDance.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "overlays/actors/ovl_En_Rz/z_en_rz.h"
@@ -26,19 +27,19 @@ void RegisterSkipRosaSistersDance() {
                 // Queue the item check, as Actor_OfferGetItem won't work normally
                 // WEEKEVENTREG_RECEIVED_ROSA_SISTERS_HEART_PIECE is set once the player obtains this Heart Piece.
                 if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_ROSA_SISTERS_HEART_PIECE) && !IS_RANDO) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                        .showGetItemCutscene = true,
-                        .param = GID_HEART_PIECE,
-                        .giveItem = [](Actor* actor, PlayState* play) {
-                            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                CustomMessage::SetActiveCustomMessage("You received a Piece of Heart!",
-                                                                      { .textboxType = 2 });
-                            } else {
-                                CustomMessage::StartTextbox("You received a Piece of Heart!\x1C\x02\x10",
-                                                            { .textboxType = 2 });
-                            }
-                            Item_Give(gPlayState, ITEM_HEART_PIECE);
-                        } });
+                    GameInteractor::Instance->Queue(GIActions::GiveItem(
+                        { .showGetItemCutscene = true,
+                          .param = GID_HEART_PIECE,
+                          .giveItem = [](Actor* actor, PlayState* play) {
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                  CustomMessage::SetActiveCustomMessage("You received a Piece of Heart!",
+                                                                        { .textboxType = 2 });
+                              } else {
+                                  CustomMessage::StartTextbox("You received a Piece of Heart!\x1C\x02\x10",
+                                                              { .textboxType = 2 });
+                              }
+                              Item_Give(gPlayState, ITEM_HEART_PIECE);
+                          } }));
                 }
                 Player* player = GET_PLAYER(gPlayState);
                 actor->parent = &player->actor;

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
@@ -1,9 +1,11 @@
+#include <optional>
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -14,11 +16,29 @@ extern "C" {
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 /*
+ * Where the player was warping from, stashed by HandleGiantsCutsceneSkip() and read back by the
+ * VB_PLAY_TRANSITION_CS hook below once we've landed in the Giants' Chamber.
+ *
+ * This is a private channel between two hooks in this file, so it's a file static rather than a
+ * queued request. It used to ride the GameInteractor queue as a transition that was never meant to
+ * execute, with the scene id smuggled through its transitionType field -- which only worked because
+ * nothing else could put a transition on the queue. That stopped being true: Sail can now queue a
+ * transition by name, and the find_if that fished this back out took whatever transition was in
+ * front, params and all.
+ */
+struct PendingGiantsWarp {
+    u16 entrance;
+    u16 cutsceneIndex;
+    SceneId fromScene;
+};
+static std::optional<PendingGiantsWarp> pendingGiantsWarp = std::nullopt;
+
+/*
  * Utility function made common so that rando actor behavior can access it while also doing other things. Mimics the
  * flags and transitions set by func_808BA10C in z_door_warp1.c.
  */
 void HandleGiantsCutsceneSkip() {
-    GIEventTransition transition;
+    PendingGiantsWarp transition = {};
     switch (gPlayState->sceneId) {
         case SCENE_MITURIN_BS: // Odolwa's Lair
             SET_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE);
@@ -46,11 +66,9 @@ void HandleGiantsCutsceneSkip() {
     /*
      * At the point of transition, the previous scene's information is lost, but we need it to set the proper Giants
      * flags. Here, we store the target transition information so that we can circumvent the Giants' Chamber cutscene.
-     * We're not actually using the queued transition normally, but using its values to alter a Giants' Chamber
-     * transition.
      */
-    transition.transitionType = gPlayState->sceneId;
-    GameInteractor::Instance->events.emplace_back(transition);
+    transition.fromScene = (SceneId)gPlayState->sceneId;
+    pendingGiantsWarp = transition;
 }
 
 // Only reached if the cutscene is skipped
@@ -101,22 +119,23 @@ void handleGiantsCheck(SceneId sceneId) {
             RANDO_SAVE_CHECKS[RC_GIANTS_CHAMBER_OATH_TO_ORDER].eligible = true;
         }
     } else if (gSaveContext.save.saveInfo.unk_EA8[1] == 1) {
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-            .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-            .giveItem =
-                [](Actor* actor, PlayState* play) {
-                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                        CustomMessage::SetActiveCustomMessage("You learned the Oath to Order!", { .textboxType = 2 });
-                    } else {
-                        CustomMessage::StartTextbox("You learned the Oath to Order!\x1C\x02\x10", { .textboxType = 2 });
-                    }
-                    Item_Give(gPlayState, ITEM_SONG_OATH);
-                },
-            .drawItem =
-                [](Actor* actor, PlayState* play) {
-                    Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                    Rando::DrawItem(RI_SONG_OATH);
-                } });
+        GameInteractor::Instance->Queue(GIActions::GiveItem(
+            { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+              .giveItem =
+                  [](Actor* actor, PlayState* play) {
+                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                          CustomMessage::SetActiveCustomMessage("You learned the Oath to Order!", { .textboxType = 2 });
+                      } else {
+                          CustomMessage::StartTextbox("You learned the Oath to Order!\x1C\x02\x10",
+                                                      { .textboxType = 2 });
+                      }
+                      Item_Give(gPlayState, ITEM_SONG_OATH);
+                  },
+              .drawItem =
+                  [](Actor* actor, PlayState* play) {
+                      Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                      Rando::DrawItem(RI_SONG_OATH);
+                  } }));
     }
 }
 
@@ -129,20 +148,16 @@ void RegisterSkipGiantsChamber() {
     COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, CVAR || IS_RANDO, {
         if (gSaveContext.save.entrance == ENTRANCE(GIANTS_CHAMBER, 0)) {
             /*
-             * The warp gate processing silently queues up an event transition with information for the particular
-             * area the player is in (Woodfall, Great Bay, etc.). This is necessary because the previous scene's
-             * information is lost during a transition, and we want to skip the Giants' Chamber that we are otherwise
-             * about to go to. We quietly use the queued transition to modify the transition in progress. The queued
-             * transition must then be erased from the event queue, otherwise it will repeat once.
+             * The warp gate processing stashed where we came from, because the previous scene's information is lost
+             * during a transition and we need it to skip the Giants' Chamber we're otherwise about to walk into. Take
+             * it (leaving nothing behind for a later warp to pick up) and redirect the transition in progress.
              */
-            auto it = std::find_if(GameInteractor::Instance->events.begin(), GameInteractor::Instance->events.end(),
-                                   [](const GIEvent& v) { return std::holds_alternative<GIEventTransition>(v); });
-            if (it != GameInteractor::Instance->events.end()) {
-                GIEventTransition transition = std::get<GIEventTransition>(*it);
-                gSaveContext.save.entrance = transition.entrance;
-                gSaveContext.save.cutsceneIndex = transition.cutsceneIndex;
-                GameInteractor::Instance->events.erase(it);
-                handleGiantsCheck((SceneId)transition.transitionType);
+            if (pendingGiantsWarp.has_value()) {
+                PendingGiantsWarp warp = *pendingGiantsWarp;
+                pendingGiantsWarp.reset();
+                gSaveContext.save.entrance = warp.entrance;
+                gSaveContext.save.cutsceneIndex = warp.cutsceneIndex;
+                handleGiantsCheck(warp.fromScene);
             }
         } else if (gSaveContext.save.entrance == ENTRANCE(WOODFALL, 0) && gSaveContext.save.cutsceneIndex == 0xFFF0) {
             // Odolwa's Lair repeat warps go straight to the Woodfall clear cutscene. Skip that too.

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "functions.h"
@@ -21,7 +22,7 @@ void RegisterSkipHealingDarmani() {
         // Played Song of Healing for Darmani in Goron Graveyard
         if (gPlayState->sceneId == SCENE_GORON_HAKA && *csId == 9) {
             if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_GORON)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                GameInteractor::Instance->Queue(GIActions::GiveItem({
                     .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                     .param = GID_MASK_GORON,
                     .giveItem =
@@ -35,7 +36,7 @@ void RegisterSkipHealingDarmani() {
                             }
                             Item_Give(gPlayState, ITEM_MASK_GORON);
                         },
-                });
+                }));
             }
             /*
              * Darmani's ghost normally goes away after a scene reload, but we're skipping that transition, so we

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "functions.h"
@@ -17,19 +18,19 @@ void RegisterSkipHealingMikau() {
         if (gPlayState->sceneId == SCENE_30GYOSON) { // Great Bay Coast
             if (*csId == 13) {                       // Played Song of Healing for Mikau
                 // Transition to Link bowing at Mikau's grave
-                GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                GameInteractor::Instance->Queue(GIActions::Transition({
                     .entrance = ENTRANCE(GREAT_BAY_COAST, 10),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,
                     .transitionType = TRANS_TYPE_FADE_BLACK,
-                });
+                }));
                 /*
                  * This scene entrance has no transition effect, so assign gSaveContext.nextTransitionType manually
                  * to prevent the snap from black to the scene.
                  */
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_ZORA)) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                    GameInteractor::Instance->Queue(GIActions::GiveItem({
                         .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                         .param = GID_MASK_ZORA,
                         .giveItem =
@@ -42,7 +43,7 @@ void RegisterSkipHealingMikau() {
                                                                 { .textboxType = 2 });
                                 }
                             },
-                    });
+                    }));
                     // Give item immediately instead of queuing it so that the gravestone and Mikau spawns behave
                     Item_Give(gPlayState, ITEM_MASK_ZORA);
                 }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -23,12 +24,12 @@ void skipHealingPamelasFather() {
      * where Pamela and her father embrace and Tatl yells at Link for killing the moment, but this
      * is easier than replicating all actor states in the skip.
      */
-    GameInteractor::Instance->events.emplace_back(GIEventTransition{
+    GameInteractor::Instance->Queue(GIActions::Transition({
         .entrance = ENTRANCE(MUSIC_BOX_HOUSE, 0),
         .cutsceneIndex = 0,
         .transitionTrigger = TRANS_TRIGGER_START,
         .transitionType = TRANS_TYPE_INSTANT,
-    });
+    }));
     SET_WEEKEVENTREG(WEEKEVENTREG_75_20); // Flag for healing Gibdo dad
 }
 
@@ -74,17 +75,17 @@ void RegisterSkipIkanaCurseCutscenes() {
                 SET_WEEKEVENTREG(WEEKEVENTREG_61_02);
                 SET_WEEKEVENTREG(WEEKEVENTREG_61_04);
                 // Kick out the player
-                GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                GameInteractor::Instance->Queue(GIActions::Transition({
                     .entrance = ENTRANCE(IKANA_CANYON, 2),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,
                     .transitionType = TRANS_TYPE_FADE_BLACK_FAST,
-                });
+                }));
                 *should = false;
             } else if (*csId == 11) { // Heal Pamela's father for the first time
                 skipHealingPamelasFather();
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_DMCHAR05, true, ITEM_MASK_GIBDO)) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+                    GameInteractor::Instance->Queue(GIActions::GiveItem({
                         .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
                         .param = GID_MASK_GIBDO,
                         .giveItem =
@@ -98,7 +99,7 @@ void RegisterSkipIkanaCurseCutscenes() {
                                 }
                                 Item_Give(gPlayState, ITEM_MASK_GIBDO);
                             },
-                    });
+                    }));
                 }
                 *should = false;
             } else if (*csId == 13) { // Heal Pamela's father subsequent times (no mask drop)
@@ -124,12 +125,12 @@ void RegisterSkipIkanaCurseCutscenes() {
         s16* csId = va_arg(args, s16*);
         if (gPlayState->sceneId == SCENE_IKANA && *csId == 20) { // Played Song of Storms for Sharp
             // Reload the scene so that all actor states are appropriate
-            GameInteractor::Instance->events.emplace_back(GIEventTransition{
+            GameInteractor::Instance->Queue(GIActions::Transition({
                 .entrance = ENTRANCE(IKANA_CANYON, 14),
                 .cutsceneIndex = 0,
                 .transitionTrigger = TRANS_TRIGGER_START,
                 .transitionType = TRANS_TYPE_INSTANT,
-            });
+            }));
             SET_WEEKEVENTREG(WEEKEVENTREG_14_04); // Healed Sharp
             *should = false;
         }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
@@ -14,24 +15,24 @@ void RegisterSkipLearningElegyOfEmptiness() {
         s16* csId = va_arg(args, s16*);
         if (gPlayState->sceneId == SCENE_IKNINSIDE && *csId == 10) { // Defeated Igos, learn Elegy of Emptiness
             if (GameInteractor_Should(VB_GIVE_ITEM_FROM_KNIGHT, true)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                    .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                    .giveItem =
-                        [](Actor* actor, PlayState* play) {
-                            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                CustomMessage::SetActiveCustomMessage("You learned the Elegy of Emptiness!",
-                                                                      { .textboxType = 2 });
-                            } else {
-                                CustomMessage::StartTextbox("You learned the Elegy of Emptiness!\x1C\x02\x10",
-                                                            { .textboxType = 2 });
-                            }
-                            Item_Give(gPlayState, ITEM_SONG_ELEGY);
-                        },
-                    .drawItem =
-                        [](Actor* actor, PlayState* play) {
-                            Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            Rando::DrawItem(RI_SONG_ELEGY);
-                        } });
+                GameInteractor::Instance->Queue(GIActions::GiveItem(
+                    { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                      .giveItem =
+                          [](Actor* actor, PlayState* play) {
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                  CustomMessage::SetActiveCustomMessage("You learned the Elegy of Emptiness!",
+                                                                        { .textboxType = 2 });
+                              } else {
+                                  CustomMessage::StartTextbox("You learned the Elegy of Emptiness!\x1C\x02\x10",
+                                                              { .textboxType = 2 });
+                              }
+                              Item_Give(gPlayState, ITEM_SONG_ELEGY);
+                          },
+                      .drawItem =
+                          [](Actor* actor, PlayState* play) {
+                              Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                              Rando::DrawItem(RI_SONG_ELEGY);
+                          } }));
             }
             *should = false;
         }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "overlays/actors/ovl_En_Ma4/z_en_ma4.h"
@@ -32,22 +33,23 @@ void RegisterSkipLearningEponasSong() {
         }
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_ROMANI, true, enMa4)) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                .showGetItemCutscene = true,
-                .giveItem =
-                    [](Actor* actor, PlayState* play) {
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                            CustomMessage::SetActiveCustomMessage("You received Epona's Song!", { .textboxType = 2 });
-                        } else {
-                            CustomMessage::StartTextbox("You received Epona's Song!\x1C\x02\x10", { .textboxType = 2 });
-                        }
-                        Item_Give(gPlayState, ITEM_SONG_EPONA);
-                    },
-                .drawItem =
-                    [](Actor* actor, PlayState* play) {
-                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(RI_SONG_EPONA);
-                    } });
+            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                { .showGetItemCutscene = true,
+                  .giveItem =
+                      [](Actor* actor, PlayState* play) {
+                          if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                              CustomMessage::SetActiveCustomMessage("You received Epona's Song!", { .textboxType = 2 });
+                          } else {
+                              CustomMessage::StartTextbox("You received Epona's Song!\x1C\x02\x10",
+                                                          { .textboxType = 2 });
+                          }
+                          Item_Give(gPlayState, ITEM_SONG_EPONA);
+                      },
+                  .drawItem =
+                      [](Actor* actor, PlayState* play) {
+                          Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                          Rando::DrawItem(RI_SONG_EPONA);
+                      } }));
         }
 
         *should = false;

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -48,24 +49,24 @@ void RegisterSkipLearningGoronLullaby() {
         isGoronSleepQueued = true;
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_GK_LULLABY, !CHECK_QUEST_ITEM(QUEST_SONG_LULLABY))) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                .giveItem =
-                    [](Actor* actor, PlayState* play) {
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                            CustomMessage::SetActiveCustomMessage("You learned the complete Goron Lullaby!",
-                                                                  { .textboxType = 2 });
-                        } else {
-                            CustomMessage::StartTextbox("You learned the complete Goron Lullaby!\x1C\x02\x10",
-                                                        { .textboxType = 2 });
-                        }
-                        Item_Give(gPlayState, ITEM_SONG_LULLABY);
-                    },
-                .drawItem =
-                    [](Actor* actor, PlayState* play) {
-                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(RI_SONG_LULLABY);
-                    } });
+            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                  .giveItem =
+                      [](Actor* actor, PlayState* play) {
+                          if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                              CustomMessage::SetActiveCustomMessage("You learned the complete Goron Lullaby!",
+                                                                    { .textboxType = 2 });
+                          } else {
+                              CustomMessage::StartTextbox("You learned the complete Goron Lullaby!\x1C\x02\x10",
+                                                          { .textboxType = 2 });
+                          }
+                          Item_Give(gPlayState, ITEM_SONG_LULLABY);
+                      },
+                  .drawItem =
+                      [](Actor* actor, PlayState* play) {
+                          Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                          Rando::DrawItem(RI_SONG_LULLABY);
+                      } }));
         }
     });
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -24,24 +25,24 @@ void RegisterSkipLearningGoronLullabyIntro() {
         SET_WEEKEVENTREG(WEEKEVENTREG_24_40);
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_JG, !CHECK_QUEST_ITEM(QUEST_SONG_LULLABY_INTRO))) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                .giveItem =
-                    [](Actor* actor, PlayState* play) {
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                            CustomMessage::SetActiveCustomMessage("You learned the Lullaby Intro!",
-                                                                  { .textboxType = 2 });
-                        } else {
-                            CustomMessage::StartTextbox("You learned the Lullaby Intro!\x1C\x02\x10",
-                                                        { .textboxType = 2 });
-                        }
-                        Item_Give(gPlayState, ITEM_SONG_LULLABY_INTRO);
-                    },
-                .drawItem =
-                    [](Actor* actor, PlayState* play) {
-                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(RI_SONG_LULLABY_INTRO);
-                    } });
+            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                  .giveItem =
+                      [](Actor* actor, PlayState* play) {
+                          if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                              CustomMessage::SetActiveCustomMessage("You learned the Lullaby Intro!",
+                                                                    { .textboxType = 2 });
+                          } else {
+                              CustomMessage::StartTextbox("You learned the Lullaby Intro!\x1C\x02\x10",
+                                                          { .textboxType = 2 });
+                          }
+                          Item_Give(gPlayState, ITEM_SONG_LULLABY_INTRO);
+                      },
+                  .drawItem =
+                      [](Actor* actor, PlayState* play) {
+                          Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                          Rando::DrawItem(RI_SONG_LULLABY_INTRO);
+                      } }));
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include <functions.h>
@@ -18,24 +19,24 @@ void RegisterSkipLearningNewWaveBossaNova() {
         s16* csId = va_arg(args, s16*);
         if (gPlayState->sceneId == SCENE_LABO && *csId == 11) {
             if (GameInteractor_Should(VB_GIVE_NEW_WAVE_BOSSA_NOVA, true)) {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                    .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                    .giveItem =
-                        [](Actor* actor, PlayState* play) {
-                            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                CustomMessage::SetActiveCustomMessage("You learned the New Wave Bossa Nova!",
-                                                                      { .textboxType = 2 });
-                            } else {
-                                CustomMessage::StartTextbox("You learned the New Wave Bossa Nova!\x1C\x02\x10",
-                                                            { .textboxType = 2 });
-                            }
-                            Item_Give(gPlayState, ITEM_SONG_NOVA);
-                        },
-                    .drawItem =
-                        [](Actor* actor, PlayState* play) {
-                            Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            Rando::DrawItem(RI_SONG_NOVA);
-                        } });
+                GameInteractor::Instance->Queue(GIActions::GiveItem(
+                    { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                      .giveItem =
+                          [](Actor* actor, PlayState* play) {
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                  CustomMessage::SetActiveCustomMessage("You learned the New Wave Bossa Nova!",
+                                                                        { .textboxType = 2 });
+                              } else {
+                                  CustomMessage::StartTextbox("You learned the New Wave Bossa Nova!\x1C\x02\x10",
+                                                              { .textboxType = 2 });
+                              }
+                              Item_Give(gPlayState, ITEM_SONG_NOVA);
+                          },
+                      .drawItem =
+                          [](Actor* actor, PlayState* play) {
+                              Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                              Rando::DrawItem(RI_SONG_NOVA);
+                          } }));
             }
             SET_WEEKEVENTREG(WEEKEVENTREG_20_40);
             *should = false;

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -27,24 +28,24 @@ void RegisterSkipLearningSonataOfAwakening() {
                 *should = false;
             } else if (*csId == 12) {
                 if (GameInteractor_Should(VB_GIVE_ITEM_FROM_MNK, true)) {
-                    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                        .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                        .giveItem =
-                            [](Actor* actor, PlayState* play) {
-                                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                    CustomMessage::SetActiveCustomMessage("You learned the Sonata of Awakening!",
-                                                                          { .textboxType = 2 });
-                                } else {
-                                    CustomMessage::StartTextbox("You learned the Sonata of Awakening!\x1C\x02\x10",
-                                                                { .textboxType = 2 });
-                                }
-                                Item_Give(gPlayState, ITEM_SONG_SONATA);
-                            },
-                        .drawItem =
-                            [](Actor* actor, PlayState* play) {
-                                Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                                Rando::DrawItem(RI_SONG_SONATA);
-                            } });
+                    GameInteractor::Instance->Queue(GIActions::GiveItem(
+                        { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                          .giveItem =
+                              [](Actor* actor, PlayState* play) {
+                                  if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                      CustomMessage::SetActiveCustomMessage("You learned the Sonata of Awakening!",
+                                                                            { .textboxType = 2 });
+                                  } else {
+                                      CustomMessage::StartTextbox("You learned the Sonata of Awakening!\x1C\x02\x10",
+                                                                  { .textboxType = 2 });
+                                  }
+                                  Item_Give(gPlayState, ITEM_SONG_SONATA);
+                              },
+                          .drawItem =
+                              [](Actor* actor, PlayState* play) {
+                                  Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                                  Rando::DrawItem(RI_SONG_SONATA);
+                              } }));
                 }
                 gPlayState->nextEntrance = ENTRANCE(DEKU_PALACE, 1);
                 gPlayState->transitionType = TRANS_TYPE_64;

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 #include <spdlog/spdlog.h>
 
 extern "C" {
@@ -77,25 +78,25 @@ void RegisterSkipLearningSongOfHealing() {
 
         if (GameInteractor_Should(VB_GIVE_ITEM_FROM_OSN, true, enOsn)) {
             // Queue up the item gives
-            GameInteractor::Instance->events.emplace_back(
-                GIEventGiveItem{ .showGetItemCutscene = true,
-                                 .giveItem =
-                                     [](Actor* actor, PlayState* play) {
-                                         if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                             CustomMessage::SetActiveCustomMessage("You received the Song of Healing!",
-                                                                                   { .textboxType = 2 });
-                                         } else {
-                                             CustomMessage::StartTextbox(
-                                                 "You received the Song of Healing!\x1C\x02\x10", { .textboxType = 2 });
-                                         }
-                                         Item_Give(gPlayState, ITEM_SONG_HEALING);
-                                     },
-                                 .drawItem =
-                                     [](Actor* actor, PlayState* play) {
-                                         Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                                         Rando::DrawItem(RI_SONG_HEALING);
-                                     } });
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                { .showGetItemCutscene = true,
+                  .giveItem =
+                      [](Actor* actor, PlayState* play) {
+                          if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                              CustomMessage::SetActiveCustomMessage("You received the Song of Healing!",
+                                                                    { .textboxType = 2 });
+                          } else {
+                              CustomMessage::StartTextbox("You received the Song of Healing!\x1C\x02\x10",
+                                                          { .textboxType = 2 });
+                          }
+                          Item_Give(gPlayState, ITEM_SONG_HEALING);
+                      },
+                  .drawItem =
+                      [](Actor* actor, PlayState* play) {
+                          Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                          Rando::DrawItem(RI_SONG_HEALING);
+                      } }));
+            GameInteractor::Instance->Queue(GIActions::GiveItem({
                 .showGetItemCutscene = true,
                 .param = GID_MASK_DEKU,
                 .giveItem =
@@ -108,7 +109,7 @@ void RegisterSkipLearningSongOfHealing() {
                         }
                         Item_Give(gPlayState, ITEM_MASK_DEKU);
                     },
-            });
+            }));
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -30,24 +31,24 @@ void RegisterSkipLearningSongOfSoaring() {
     // Then, once this textId is opened for the first time, give the player the reward. (unless we're in rando)
     COND_ID_HOOK(OnOpenText, ENGRAVING_TEXT_ID, CVAR && !IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
         if (!CHECK_QUEST_ITEM(QUEST_SONG_SOARING)) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                .giveItem =
-                    [](Actor* actor, PlayState* play) {
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                            CustomMessage::SetActiveCustomMessage("You learned the Song of Soaring!",
-                                                                  { .textboxType = 2 });
-                        } else {
-                            CustomMessage::StartTextbox("You learned the Song of Soaring!\x1C\x02\x10",
-                                                        { .textboxType = 2 });
-                        }
-                        Item_Give(gPlayState, ITEM_SONG_SOARING);
-                    },
-                .drawItem =
-                    [](Actor* actor, PlayState* play) {
-                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(RI_SONG_SOARING);
-                    } });
+            GameInteractor::Instance->Queue(GIActions::GiveItem(
+                { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                  .giveItem =
+                      [](Actor* actor, PlayState* play) {
+                          if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                              CustomMessage::SetActiveCustomMessage("You learned the Song of Soaring!",
+                                                                    { .textboxType = 2 });
+                          } else {
+                              CustomMessage::StartTextbox("You learned the Song of Soaring!\x1C\x02\x10",
+                                                          { .textboxType = 2 });
+                          }
+                          Item_Give(gPlayState, ITEM_SONG_SOARING);
+                      },
+                  .drawItem =
+                      [](Actor* actor, PlayState* play) {
+                          Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                          Rando::DrawItem(RI_SONG_SOARING);
+                      } }));
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -21,24 +22,24 @@ void RegisterSkipLearningSongOfStorms() {
             if (IS_RANDO) {
                 RANDO_SAVE_CHECKS[RC_BENEATH_THE_GRAVEYARD_SONG_OF_STORMS].eligible = true;
             } else {
-                GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                    .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                    .giveItem =
-                        [](Actor* actor, PlayState* play) {
-                            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                                CustomMessage::SetActiveCustomMessage("You learned the Song of Storms!",
-                                                                      { .textboxType = 2 });
-                            } else {
-                                CustomMessage::StartTextbox("You learned the Song of Storms!\x1C\x02\x10",
-                                                            { .textboxType = 2 });
-                            }
-                            Item_Give(gPlayState, ITEM_SONG_STORMS);
-                        },
-                    .drawItem =
-                        [](Actor* actor, PlayState* play) {
-                            Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            Rando::DrawItem(RI_SONG_STORMS);
-                        } });
+                GameInteractor::Instance->Queue(GIActions::GiveItem(
+                    { .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+                      .giveItem =
+                          [](Actor* actor, PlayState* play) {
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                  CustomMessage::SetActiveCustomMessage("You learned the Song of Storms!",
+                                                                        { .textboxType = 2 });
+                              } else {
+                                  CustomMessage::StartTextbox("You learned the Song of Storms!\x1C\x02\x10",
+                                                              { .textboxType = 2 });
+                              }
+                              Item_Give(gPlayState, ITEM_SONG_STORMS);
+                          },
+                      .drawItem =
+                          [](Actor* actor, PlayState* play) {
+                              Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                              Rando::DrawItem(RI_SONG_STORMS);
+                          } }));
             }
             *should = false;
         }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "functions.h"
@@ -22,23 +23,24 @@ void RegisterSkipLearningSongOfTime() {
         *should = false;
         // This typically gets set in the cutscene
         gSaveContext.save.playerForm = PLAYER_FORM_DEKU;
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-            .showGetItemCutscene = true,
-            .param = GID_MASK_DEKU,
-            .giveItem =
-                [](Actor* actor, PlayState* play) {
-                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                        CustomMessage::SetActiveCustomMessage("You received the Song of Time!", { .textboxType = 2 });
-                    } else {
-                        CustomMessage::StartTextbox("You received the Song of Time!\x1C\x02\x10", { .textboxType = 2 });
-                    }
-                    Item_Give(gPlayState, ITEM_SONG_TIME);
-                },
-            .drawItem =
-                [](Actor* actor, PlayState* play) {
-                    Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                    Rando::DrawItem(RI_SONG_TIME);
-                } });
+        GameInteractor::Instance->Queue(GIActions::GiveItem(
+            { .showGetItemCutscene = true,
+              .param = GID_MASK_DEKU,
+              .giveItem =
+                  [](Actor* actor, PlayState* play) {
+                      if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                          CustomMessage::SetActiveCustomMessage("You received the Song of Time!", { .textboxType = 2 });
+                      } else {
+                          CustomMessage::StartTextbox("You received the Song of Time!\x1C\x02\x10",
+                                                      { .textboxType = 2 });
+                      }
+                      Item_Give(gPlayState, ITEM_SONG_TIME);
+                  },
+              .drawItem =
+                  [](Actor* actor, PlayState* play) {
+                      Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                      Rando::DrawItem(RI_SONG_TIME);
+                  } }));
     });
 }
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -20,11 +21,10 @@ void RegisterSkipPrincessDelivery() {
             SET_WEEKEVENTREG(WEEKEVENTREG_23_20);
 
             // Set up transition to Deku Palace throne room
-            GameInteractor::Instance->events.emplace_back(
-                GIEventTransition{ .entrance = ENTRANCE(DEKU_KINGS_CHAMBER, 3),
-                                   .cutsceneIndex = 0,
-                                   .transitionTrigger = TRANS_TRIGGER_START,
-                                   .transitionType = TRANS_TYPE_FADE_BLACK });
+            GameInteractor::Instance->Queue(GIActions::Transition({ .entrance = ENTRANCE(DEKU_KINGS_CHAMBER, 3),
+                                                                    .cutsceneIndex = 0,
+                                                                    .transitionTrigger = TRANS_TRIGGER_START,
+                                                                    .transitionType = TRANS_TYPE_FADE_BLACK }));
             *should = false;
         }
     });

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -23,12 +24,12 @@ void RegisterSkipStoppingMoon() {
                                                                          CHECK_QUEST_ITEM(QUEST_REMAINS_GYORG) &&
                                                                          CHECK_QUEST_ITEM(QUEST_REMAINS_TWINMOLD))) {
                     *should = false;
-                    GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                    GameInteractor::Instance->Queue(GIActions::Transition({
                         .entrance = ENTRANCE(THE_MOON, 0),
                         .cutsceneIndex = 0,
                         .transitionTrigger = TRANS_TRIGGER_START,
                         .transitionType = TRANS_TYPE_INSTANT,
-                    });
+                    }));
                     SET_WEEKEVENTREG(WEEKEVENTREG_25_02); // giants called to tower
                     SET_WEEKEVENTREG(WEEKEVENTREG_93_04); // watched giants stopping moon cs (persistant)
                 }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "variables.h"
@@ -39,12 +40,12 @@ void RegisterSkipWakingAndRidingTurtle() {
             // 13 is turtle leaving zora cape first time, 15 is subsequent times
             if (*csId == 13 || *csId == 15) {
                 *should = false;
-                GameInteractor::Instance->events.emplace_back(GIEventTransition{
+                GameInteractor::Instance->Queue(GIActions::Transition({
                     .entrance = ENTRANCE(GREAT_BAY_TEMPLE, 0),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,
                     .transitionType = TRANS_TYPE_FADE_BLACK_FAST,
-                });
+                }));
             }
         }
     });

--- a/mm/2s2h/Enhancements/DemoBehavior.cpp
+++ b/mm/2s2h/Enhancements/DemoBehavior.cpp
@@ -2,6 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "z64actor.h"
@@ -31,7 +32,7 @@ void RegisterDemoBehavior() {
 
                     // You can put whatever you want here. For instance you can use the GI queue to queue up a different
                     // kind of item give:
-                    GameInteractor::Instance->events.push_back(GIEventGiveItem{
+                    GameInteractor::Instance->Queue(GIActions::GiveItem({
                         .showGetItemCutscene = true,
                         .param = GID_RUPEE_GREEN,
                         .giveItem =
@@ -50,7 +51,7 @@ void RegisterDemoBehavior() {
                                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
                                 GetItem_Draw(play, CUSTOM_ITEM_PARAM);
                             },
-                    });
+                    }));
 
                     // Or you can spawn another CustomItem to give an item that way, but the GI queue is more flexible
                     // and reliable
@@ -104,22 +105,6 @@ void RegisterDemoBehavior() {
                                                                       .textboxType = 2,
                                                                       .icon = 0x3D,
                                                                   });
-
-            // Pot Hydra
-            // GameInteractor::Instance->events.push_back(GIEventSpawnActor{
-            //     .actorId = ACTOR_OBJ_TSUBO,
-            //     .posX = 50.0f,
-            //     .posY = 0,
-            //     .posZ = -40.0f, // Behind the player
-            //     .relativeCoords = true,
-            // });
-            // GameInteractor::Instance->events.push_back(GIEventSpawnActor{
-            //     .actorId = ACTOR_OBJ_TSUBO,
-            //     .posX = -50.0f,
-            //     .posY = 0,
-            //     .posZ = -50.0f, // Behind the player
-            //     .relativeCoords = true,
-            // });
         }
     });
 

--- a/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 #define CVAR_NAME "gEnhancements.Timesavers.AutoBankDeposit"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
@@ -35,22 +36,22 @@ static void GrantBankFirstReward() {
         u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
         s16 itemDrawId = (walletLevel == 0) ? (s16)GID_WALLET_ADULT : (s16)GID_WALLET_GIANT;
 
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-            .showGetItemCutscene = true, .param = itemDrawId, .giveItem = [](Actor* actor, PlayState* play) {
-                u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
-                ItemId wallet = (walletLevel == 0) ? ITEM_WALLET_ADULT : ITEM_WALLET_GIANT;
-                const char* walletName = (walletLevel == 0) ? "Adult's Wallet" : "Giant's Wallet";
+        GameInteractor::Instance->Queue(GIActions::GiveItem(
+            { .showGetItemCutscene = true, .param = itemDrawId, .giveItem = [](Actor* actor, PlayState* play) {
+                 u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
+                 ItemId wallet = (walletLevel == 0) ? ITEM_WALLET_ADULT : ITEM_WALLET_GIANT;
+                 const char* walletName = (walletLevel == 0) ? "Adult's Wallet" : "Giant's Wallet";
 
-                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                    CustomMessage::SetActiveCustomMessage(std::string("You got ") + walletName + "!",
-                                                          { .textboxType = 2 });
-                } else {
-                    CustomMessage::StartTextbox(std::string("You got ") + walletName + "!\x1C\x02\x10",
-                                                { .textboxType = 2 });
-                }
+                 if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                     CustomMessage::SetActiveCustomMessage(std::string("You got ") + walletName + "!",
+                                                           { .textboxType = 2 });
+                 } else {
+                     CustomMessage::StartTextbox(std::string("You got ") + walletName + "!\x1C\x02\x10",
+                                                 { .textboxType = 2 });
+                 }
 
-                Item_Give(play, wallet);
-            } });
+                 Item_Give(play, wallet);
+             } }));
     }
 }
 
@@ -60,16 +61,16 @@ static void GrantBankInterestReward() {
     if (IS_RANDO) {
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
     } else {
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-            .showGetItemCutscene = true, .param = GID_RUPEE_BLUE, .giveItem = [](Actor* actor, PlayState* play) {
-                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                    CustomMessage::SetActiveCustomMessage("You got a Blue Rupee!", { .textboxType = 2 });
-                } else {
-                    CustomMessage::StartTextbox("You got a Blue Rupee!\x1C\x02\x10", { .textboxType = 2 });
-                }
+        GameInteractor::Instance->Queue(GIActions::GiveItem(
+            { .showGetItemCutscene = true, .param = GID_RUPEE_BLUE, .giveItem = [](Actor* actor, PlayState* play) {
+                 if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                     CustomMessage::SetActiveCustomMessage("You got a Blue Rupee!", { .textboxType = 2 });
+                 } else {
+                     CustomMessage::StartTextbox("You got a Blue Rupee!\x1C\x02\x10", { .textboxType = 2 });
+                 }
 
-                Item_Give(play, ITEM_RUPEE_BLUE);
-            } });
+                 Item_Give(play, ITEM_RUPEE_BLUE);
+             } }));
     }
 }
 
@@ -79,16 +80,16 @@ static void GrantBankFinalReward() {
     if (IS_RANDO) {
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_PIECE_OF_HEART].eligible = true;
     } else {
-        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-            .showGetItemCutscene = true, .param = GID_HEART_PIECE, .giveItem = [](Actor* actor, PlayState* play) {
-                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                    CustomMessage::SetActiveCustomMessage("You got a Piece of Heart!", { .textboxType = 2 });
-                } else {
-                    CustomMessage::StartTextbox("You got a Piece of Heart!\x1C\x02\x10", { .textboxType = 2 });
-                }
+        GameInteractor::Instance->Queue(GIActions::GiveItem(
+            { .showGetItemCutscene = true, .param = GID_HEART_PIECE, .giveItem = [](Actor* actor, PlayState* play) {
+                 if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                     CustomMessage::SetActiveCustomMessage("You got a Piece of Heart!", { .textboxType = 2 });
+                 } else {
+                     CustomMessage::StartTextbox("You got a Piece of Heart!\x1C\x02\x10", { .textboxType = 2 });
+                 }
 
-                Item_Give(play, ITEM_HEART_PIECE);
-            } });
+                 Item_Give(play, ITEM_HEART_PIECE);
+             } }));
     }
 }
 

--- a/mm/2s2h/Enhancements/Timesavers/GalleryTwofer.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/GalleryTwofer.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h"
@@ -37,7 +38,7 @@ void RegisterGalleryTwofer() {
         }
 
         if (!IS_RANDO && queueHeartPiece) {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            GameInteractor::Instance->Queue(GIActions::GiveItem({
                 .showGetItemCutscene = true,
                 .param = GID_HEART_PIECE,
                 .giveItem =
@@ -51,7 +52,7 @@ void RegisterGalleryTwofer() {
                         }
                         Item_Give(gPlayState, ITEM_HEART_PIECE);
                     },
-            });
+            }));
         }
     });
 }

--- a/mm/2s2h/GameInteractor/Actions/Actions.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Actions.cpp
@@ -1,0 +1,174 @@
+#include "Actions.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <spdlog/spdlog.h>
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+// Has external linkage in z_camera.c, but isn't in any header.
+Vec3f Camera_CalcUpVec(s16 pitch, s16 yaw, s16 roll);
+}
+
+namespace GIActions {
+
+// Function-local static so the registry exists before any Register in another TU runs.
+static std::vector<Definition>& Registry() {
+    static std::vector<Definition> registry;
+    return registry;
+}
+
+Register::Register(Definition definition) {
+    Registry().push_back(std::move(definition));
+}
+
+const std::vector<Definition>& All() {
+    return Registry();
+}
+
+const Definition* Get(GIActionId id) {
+    for (const auto& definition : Registry()) {
+        if (definition.id == id) {
+            return &definition;
+        }
+    }
+    return nullptr;
+}
+
+const Definition* FindByName(std::string_view name) {
+    for (const auto& definition : Registry()) {
+        if (name == definition.name) {
+            return &definition;
+        }
+    }
+    return nullptr;
+}
+
+std::optional<GIAction> Definition::Build(GIParams params, std::string* error) const {
+    if (auto problem = GIParamsValidate(schema, params)) {
+        if (error != nullptr) {
+            *error = *problem;
+        }
+        SPDLOG_WARN("[GameInteractor] Rejected '{}': {}", name, *problem);
+        return std::nullopt;
+    }
+
+    return GIAction{
+        .id = id,
+        .params = std::move(params),
+        .duration = defaultDuration,
+        .canApply = canApply,
+        .onStart = onStart,
+        .onTick = onTick,
+        .onEnd = onEnd,
+    };
+}
+
+GIActionAvailability Gates::NotOnHorse(const GIAction&) {
+    if (gPlayState == NULL) {
+        return GI_AVAILABILITY_NOT_YET;
+    }
+    if (GET_PLAYER(gPlayState)->stateFlags1 & PLAYER_STATE1_800000) {
+        return GI_AVAILABILITY_NOT_YET;
+    }
+    return GI_AVAILABILITY_READY;
+}
+
+Player* PlayerOrNull() {
+    if (gPlayState == NULL) {
+        return NULL;
+    }
+    return GET_PLAYER(gPlayState);
+}
+
+int32_t Setting::Snapshot(const char* cvar) {
+    return CVarGetInteger(cvar, Setting::ABSENT);
+}
+
+void Setting::Restore(const char* cvar, int32_t previous) {
+    if (previous == Setting::ABSENT) {
+        CVarClear(cvar);
+    } else {
+        CVarSetInteger(cvar, previous);
+    }
+}
+
+void CameraRoll::Apply(Camera* camera, int16_t offset) {
+    if (camera == NULL || camera->camId != CAM_ID_MAIN) {
+        return;
+    }
+
+    // Recomputed from camDir each frame; rotating camera->up in place would compound the offset.
+    camera->up = Camera_CalcUpVec(camera->camDir.x, camera->camDir.y, camera->roll + offset);
+    camera->viewFlags |= CAM_VIEW_UP;
+}
+
+// File statics because REGISTER_VB_SHOULD expands to a captureless lambda.
+static float sHeightScale = 1.0f;
+static HOOK_ID sFocalHeightHook = 0;
+static HOOK_ID sLegIkHook = 0;
+
+// Camera_Normal1 divides by the focal height, so it must never reach zero.
+#define MIN_FOCAL_HEIGHT 1.0f
+
+static void InstallScaleCompensation() {
+    if (sFocalHeightHook != 0) {
+        return;
+    }
+
+    // The follow cam frames against a fixed per-form height constant, so scale it too or a resized
+    // player is framed from the normal distance.
+    sFocalHeightHook = REGISTER_VB_SHOULD(VB_MODIFY_CAMERA_FOCAL_HEIGHT, {
+        f32* height = va_arg(args, f32*);
+
+        *height *= sHeightScale;
+        if (*height < MIN_FOCAL_HEIGHT) {
+            *height = MIN_FOCAL_HEIGHT;
+        }
+    });
+
+    // The leg IK solves against limb lengths baked for a normal-sized player and breaks at any
+    // other scale, so skip it; all it does is plant the feet on slopes.
+    sLegIkHook = REGISTER_VB_SHOULD(VB_NOT_ADJUST_PLAYER_LEGS, { *should = true; });
+}
+
+static void RemoveScaleCompensation() {
+    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sFocalHeightHook);
+    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sLegIkHook);
+    sFocalHeightHook = 0;
+    sLegIkHook = 0;
+}
+
+void PlayerScale::Set(float x, float y, float z) {
+    // The camera frames against height, so y is the axis it follows.
+    sHeightScale = y;
+    InstallScaleCompensation();
+
+    Player* player = PlayerOrNull();
+    if (player == NULL) {
+        return;
+    }
+
+    player->actor.scale.x = BASE * x;
+    player->actor.scale.y = BASE * y;
+    player->actor.scale.z = BASE * z;
+}
+
+void PlayerScale::Reset() {
+    RemoveScaleCompensation();
+    sHeightScale = 1.0f;
+
+    Player* player = PlayerOrNull();
+    if (player == NULL) {
+        return;
+    }
+
+    player->actor.scale.x = BASE;
+    player->actor.scale.y = BASE;
+    player->actor.scale.z = BASE;
+}
+
+} // namespace GIActions

--- a/mm/2s2h/GameInteractor/Actions/Actions.h
+++ b/mm/2s2h/GameInteractor/Actions/Actions.h
@@ -1,0 +1,109 @@
+#ifndef GAME_INTERACTOR_ACTIONS_H
+#define GAME_INTERACTOR_ACTIONS_H
+
+#ifdef __cplusplus
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "2s2h/GameInteractor/GameInteractorAction.h"
+
+extern "C" {
+#include "z64.h"
+}
+
+namespace GIActions {
+
+struct Definition {
+    GIActionId id;
+    // Stable identifier remotes address actions by; renaming one is a protocol break.
+    const char* name;
+    const char* displayName;
+    GIValence valence = GI_VALENCE_NEUTRAL;
+    uint32_t defaultDuration = 0; // Frames. 0 means instant.
+    GIStacking stacking = GI_STACK_QUEUE;
+    GIExclusionGroup exclusionGroup = GI_EXCLUSION_NONE;
+    std::vector<GIParamSpec> schema = {};
+
+    GIActionGate canApply = nullptr;
+    GIActionFunc onStart = nullptr;
+    GIActionFunc onTick = nullptr;
+    GIActionFunc onEnd = nullptr;
+
+    bool IsTimed() const {
+        return defaultDuration > 0 || onTick != nullptr || onEnd != nullptr;
+    }
+
+    // Validates `params` against the schema; on failure returns nullopt and fills `error`.
+    std::optional<GIAction> Build(GIParams params, std::string* error = nullptr) const;
+};
+
+struct Register {
+    explicit Register(Definition definition);
+};
+
+const std::vector<Definition>& All();
+const Definition* Get(GIActionId id);
+const Definition* FindByName(std::string_view name);
+
+namespace Gates {
+GIActionAvailability NotOnHorse(const GIAction& action);
+} // namespace Gates
+
+Player* PlayerOrNull();
+
+namespace Setting {
+// Snapshot/Restore for a cvar an action borrows; ABSENT means there was no value to put back.
+inline constexpr int32_t ABSENT = INT32_MIN;
+
+int32_t Snapshot(const char* cvar);
+void Restore(const char* cvar, int32_t previous);
+} // namespace Setting
+
+namespace CameraRoll {
+// Adds `offset` to the main camera's roll for this frame. Call from an AfterCameraUpdate hook.
+void Apply(Camera* camera, int16_t offset);
+} // namespace CameraRoll
+
+namespace PlayerScale {
+// The scale Player_Init gives the player actor.
+inline constexpr float BASE = 0.01f;
+
+// Re-apply every tick: scene transitions and save loads rebuild the player actor.
+void Set(float x, float y, float z);
+void Reset();
+} // namespace PlayerScale
+
+// MARK: - Typed builders for internal C++ callers
+
+struct GiveItemArgs {
+    // Whether to show the get item cutscene. If true and the player is in the air, the player is
+    // frozen for a few seconds instead. If this is true you _must_ call
+    // CustomMessage::SetActiveCustomMessage in giveItem, otherwise you'll just see a blank message.
+    bool showGetItemCutscene;
+    // Arbitrary s16 readable from the give/draw functions via CUSTOM_ITEM_PARAM.
+    s16 param;
+    // Run in the context of an item00 actor. Not usually important, but useful in some cases.
+    ActorFunc giveItem;
+    ActorFunc drawItem;
+};
+
+// Spawns a custom item on the player and delivers it once they pick it up, holding the queue for
+// as long as that takes.
+GIAction GiveItem(GiveItemArgs args);
+
+struct TransitionArgs {
+    u16 entrance;
+    u16 cutsceneIndex = 0;
+    s8 transitionTrigger = TRANS_TRIGGER_START;
+    u8 transitionType = TRANS_TYPE_FADE_BLACK;
+};
+GIAction Transition(TransitionArgs args);
+
+} // namespace GIActions
+
+#endif // __cplusplus
+
+#endif // GAME_INTERACTOR_ACTIONS_H

--- a/mm/2s2h/GameInteractor/Actions/Blast.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Blast.cpp
@@ -1,0 +1,27 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+void func_80833B18(PlayState* play, Player* thisx, s32 arg2, f32 speed, f32 velocityY, s16 arg5,
+                   s32 invincibilityTimer);
+}
+
+static GIActions::Register blastAction({
+    .id = GI_ACTION_BLAST,
+    .name = "blast",
+    .displayName = "Blast",
+    .valence = GI_VALENCE_NEGATIVE,
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            Player* player = GET_PLAYER(gPlayState);
+
+            player->actor.colChkInfo.damage = 16;
+            func_80833B18(gPlayState, player, 2, 0, 0, 0, 0);
+            Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_BOM, player->actor.world.pos.x,
+                        player->actor.world.pos.y, player->actor.world.pos.z, 1, 0, 0, 0);
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/BouncingBButton.cpp
+++ b/mm/2s2h/GameInteractor/Actions/BouncingBButton.cpp
@@ -1,0 +1,84 @@
+#include "Actions.h"
+
+#include "2s2h/BenGui/HudEditor.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+// The HUD is laid out in a 320x240 box, and the button art is 32x32.
+#define HUD_WIDTH 320
+#define HUD_HEIGHT 240
+#define B_BUTTON_SIZE 32
+
+static float sX = 0.0f;
+static float sY = 0.0f;
+static float sVelX = 0.0f;
+static float sVelY = 0.0f;
+
+static int32_t sPreviousMode = GIActions::Setting::ABSENT;
+static int32_t sPreviousX = GIActions::Setting::ABSENT;
+static int32_t sPreviousY = GIActions::Setting::ABSENT;
+
+// Clamped as well as reflected, so an overshoot can't leave the button stuck outside the box.
+static void Bounce(float& pos, float& velocity, float limit) {
+    pos += velocity;
+
+    if (pos <= 0.0f) {
+        pos = 0.0f;
+        velocity = -velocity;
+    } else if (pos >= limit) {
+        pos = limit;
+        velocity = -velocity;
+    }
+}
+
+// Rides the Hud Editor cvars so the background, icon and ammo count move together; MOVABLE_43
+// keeps it inside the 4:3 box at any window size.
+static GIActions::Register bouncingBButtonAction({
+    .id = GI_ACTION_BOUNCING_B_BUTTON,
+    .name = "bouncingBButton",
+    .displayName = "Bouncing B Button",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .onStart =
+        [](GIAction& action) {
+            const HudEditorElement& b = hudEditorElements[HUD_EDITOR_ELEMENT_B];
+
+            sPreviousMode = GIActions::Setting::Snapshot(b.modeCvar);
+            sPreviousX = GIActions::Setting::Snapshot(b.xCvar);
+            sPreviousY = GIActions::Setting::Snapshot(b.yCvar);
+
+            sX = b.defaultX;
+            sY = b.defaultY;
+
+            // Always diagonal, like the screensaver.
+            float speed = 2.0f;
+            sVelX = (Rand_Next() & 1) ? speed : -speed;
+            sVelY = (Rand_Next() & 1) ? speed : -speed;
+        },
+    .onTick =
+        [](GIAction& action) {
+            const HudEditorElement& b = hudEditorElements[HUD_EDITOR_ELEMENT_B];
+
+            Bounce(sX, sVelX, HUD_WIDTH - B_BUTTON_SIZE);
+            Bounce(sY, sVelY, HUD_HEIGHT - B_BUTTON_SIZE);
+
+            // Re-applied every tick so the Hud Editor can't quietly hand the button back mid-bounce.
+            CVarSetInteger(b.modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_43);
+            CVarSetInteger(b.xCvar, (int32_t)sX);
+            CVarSetInteger(b.yCvar, (int32_t)sY);
+        },
+    .onEnd =
+        [](GIAction& action) {
+            const HudEditorElement& b = hudEditorElements[HUD_EDITOR_ELEMENT_B];
+
+            GIActions::Setting::Restore(b.modeCvar, sPreviousMode);
+            GIActions::Setting::Restore(b.xCvar, sPreviousX);
+            GIActions::Setting::Restore(b.yCvar, sPreviousY);
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Burn.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Burn.cpp
@@ -1,0 +1,28 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+void func_80833B18(PlayState* play, Player* thisx, s32 arg2, f32 speed, f32 velocityY, s16 arg5,
+                   s32 invincibilityTimer);
+}
+
+static GIActions::Register burnAction({
+    .id = GI_ACTION_BURN,
+    .name = "burn",
+    .displayName = "Burn",
+    .valence = GI_VALENCE_NEGATIVE,
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            Player* player = GET_PLAYER(gPlayState);
+
+            for (int i = 0; i < 18; i++) {
+                player->bodyFlameTimers[i] = static_cast<uint8_t>(Rand_S16Offset(0, 200));
+            }
+            player->bodyIsBurning = true;
+            func_80833B18(gPlayState, player, 0, 0, 0, 0, 0);
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/ButtonRoulette.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ButtonRoulette.cpp
@@ -1,0 +1,107 @@
+#include "Actions.h"
+
+#include "2s2h_assets.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <utility>
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+// Defined in Enhancements/Equipment/BombArrows.cpp, and reached the same way ItemUnequip.cpp and
+// ArrowCycle.cpp reach them.
+extern bool IsBombArrowButton(s32 slot, bool isDpad);
+extern void SetBombArrowButton(s32 slot, bool state, bool isDpad);
+
+// With D-pad equips off, an item shuffled onto the D-pad would vanish from the player's buttons.
+#define CVAR_DPAD_EQUIPS "gEnhancements.Dpad.DpadEquips"
+
+struct ButtonSlot {
+    s32 slot;
+    bool isDpad;
+};
+
+static const ButtonSlot sSlots[] = {
+    { EQUIP_SLOT_C_LEFT, false }, { EQUIP_SLOT_C_DOWN, false }, { EQUIP_SLOT_C_RIGHT, false },
+    { EQUIP_SLOT_D_RIGHT, true }, { EQUIP_SLOT_D_LEFT, true },  { EQUIP_SLOT_D_DOWN, true },
+    { EQUIP_SLOT_D_UP, true },
+};
+static const size_t sCButtonCount = 3;
+
+struct Assignment {
+    u8 item;
+    u8 invSlot;
+    bool bombArrow;
+};
+
+// Form index 0 rather than CUR_FORM: only EQUIP_SLOT_B is per-form.
+static Assignment ReadSlot(const ButtonSlot& button) {
+    if (button.isDpad) {
+        return { DPAD_BUTTON_ITEM_EQUIP(0, button.slot), DPAD_SLOT_EQUIP(0, button.slot),
+                 IsBombArrowButton(button.slot, true) };
+    }
+    return { BUTTON_ITEM_EQUIP(0, button.slot), C_SLOT_EQUIP(0, button.slot), IsBombArrowButton(button.slot, false) };
+}
+
+static void WriteSlot(const ButtonSlot& button, const Assignment& assignment) {
+    if (button.isDpad) {
+        DPAD_BUTTON_ITEM_EQUIP(0, button.slot) = assignment.item;
+        DPAD_SLOT_EQUIP(0, button.slot) = assignment.invSlot;
+
+        if (assignment.item < ARRAY_COUNT(gItemIcons)) {
+            Interface_Dpad_LoadItemIconImpl(gPlayState, (u8)button.slot);
+        } else {
+            // That function's clear path writes over a C button's icon; only its set path can be trusted.
+            gPlayState->interfaceCtx.iconItemSegment[DPAD_BUTTON(button.slot) + EQUIP_SLOT_MAX] = (char*)gEmptyTexture;
+        }
+    } else {
+        BUTTON_ITEM_EQUIP(0, button.slot) = assignment.item;
+        C_SLOT_EQUIP(0, button.slot) = assignment.invSlot;
+        Interface_LoadItemIconImpl(gPlayState, (u8)button.slot);
+    }
+
+    SetBombArrowButton(button.slot, assignment.bombArrow, button.isDpad);
+}
+
+// Permutes whatever is on the buttons, C and D-pad together, so items cross between the two.
+static void ShuffleButtons() {
+    size_t count = CVarGetInteger(CVAR_DPAD_EQUIPS, 0) ? ARRAY_COUNT(sSlots) : sCButtonCount;
+    Assignment assignments[ARRAY_COUNT(sSlots)];
+
+    for (size_t i = 0; i < count; i++) {
+        assignments[i] = ReadSlot(sSlots[i]);
+    }
+
+    // Fisher-Yates; an identity shuffle is intentionally possible.
+    for (size_t i = count - 1; i > 0; i--) {
+        std::swap(assignments[i], assignments[Rand_Next() % (i + 1)]);
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        WriteSlot(sSlots[i], assignments[i]);
+    }
+}
+
+// The last shuffle deliberately sticks -- nothing is lost, and an onEnd restore would fight
+// clearButtons run mid-roulette.
+static GIActions::Register buttonRouletteAction({
+    .id = GI_ACTION_BUTTON_ROULETTE,
+    .name = "buttonRoulette",
+    .displayName = "Button Roulette",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .onTick =
+        [](GIAction& action) {
+            if (gPlayState == NULL) {
+                return;
+            }
+            // ~3s between shuffles; elapsed is 0 on the first tick, so the first lands immediately.
+            if (action.elapsed % (20 * 3) == 0) {
+                ShuffleButtons();
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/CameraTilt.cpp
+++ b/mm/2s2h/GameInteractor/Actions/CameraTilt.cpp
@@ -1,0 +1,52 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static const uint32_t sRerollInterval = 20 * 2; // 2 seconds
+static const s16 sTiltStep = 0x100;             // ~1.4 degrees per frame
+
+static HOOK_ID sCameraHook = 0;
+static s16 sTiltTarget = 0;
+static s16 sTiltCurrent = 0;
+
+static GIActions::Register cameraTiltAction({
+    .id = GI_ACTION_CAMERA_TILT,
+    .name = "cameraTilt",
+    .displayName = "Camera Tilt",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .exclusionGroup = GI_EXCLUSION_CAMERA_ROLL,
+    .schema =
+        {
+            // Degrees either side of upright.
+            { .name = "maxTilt", .type = GI_PARAM_FLOAT, .defaultValue = 25.0f, .min = 1.0f, .max = 180.0f },
+        },
+    .onStart =
+        [](GIAction& action) {
+            sTiltTarget = 0;
+            sTiltCurrent = 0;
+
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::AfterCameraUpdate>(sCameraHook);
+            sCameraHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterCameraUpdate>(
+                [](Camera* camera) { GIActions::CameraRoll::Apply(camera, sTiltCurrent); });
+        },
+    .onTick =
+        [](GIAction& action) {
+            if (action.elapsed % sRerollInterval == 0) {
+                sTiltTarget = CAM_DEG_TO_BINANG(Rand_CenteredFloat(action.params.Float("maxTilt") * 2.0f));
+            }
+            Math_StepToS(&sTiltCurrent, sTiltTarget, sTiltStep);
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::AfterCameraUpdate>(sCameraHook);
+            sCameraHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/ClearButtons.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ClearButtons.cpp
@@ -1,0 +1,41 @@
+#include "Actions.h"
+
+#include "2s2h_assets.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+// Defined in Enhancements/Equipment/BombArrows.cpp, and reached the same way ItemUnequip.cpp and
+// ArrowCycle.cpp reach it.
+extern void SetBombArrowButton(s32 slot, bool state, bool isDpad);
+
+// Form index 0 rather than CUR_FORM throughout: only EQUIP_SLOT_B is per-form. The D-pad half is
+// cleared even with its equips off -- harmless, and it leaves nothing stale.
+static GIActions::Register clearButtonsAction({
+    .id = GI_ACTION_CLEAR_BUTTONS,
+    .name = "clearButtons",
+    .displayName = "Clear Buttons",
+    .valence = GI_VALENCE_NEGATIVE,
+    .onStart =
+        [](GIAction& action) {
+            for (s32 slot = EQUIP_SLOT_C_LEFT; slot <= EQUIP_SLOT_C_RIGHT; slot++) {
+                BUTTON_ITEM_EQUIP(0, slot) = ITEM_NONE;
+                C_SLOT_EQUIP(0, slot) = SLOT_NONE;
+                Interface_LoadItemIconImpl(gPlayState, slot);
+                SetBombArrowButton(slot, false, false);
+            }
+
+            for (s32 slot = EQUIP_SLOT_D_RIGHT; slot <= EQUIP_SLOT_D_UP; slot++) {
+                DPAD_BUTTON_ITEM_EQUIP(0, slot) = ITEM_NONE;
+                DPAD_SLOT_EQUIP(0, slot) = SLOT_NONE;
+                // Interface_Dpad_LoadItemIconImpl's clear path writes over a C button's icon.
+                gPlayState->interfaceCtx.iconItemSegment[DPAD_BUTTON(slot) + EQUIP_SLOT_MAX] = (char*)gEmptyTexture;
+                SetBombArrowButton(slot, false, true);
+            }
+
+            Audio_PlaySfx(NA_SE_SY_DECIDE);
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/DamageMultiplier.cpp
+++ b/mm/2s2h/GameInteractor/Actions/DamageMultiplier.cpp
@@ -1,0 +1,41 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+// File static because REGISTER_VB_SHOULD expands to a captureless lambda.
+static float sMultiplier = 2.0f;
+static HOOK_ID sDamageHook = 0;
+
+static GIActions::Register damageMultiplierAction({
+    .id = GI_ACTION_DAMAGE_MULTIPLIER,
+    .name = "damageMultiplier",
+    .displayName = "Damage Multiplier",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            { .name = "multiplier", .type = GI_PARAM_FLOAT, .defaultValue = 2.0f, .min = 1.0f, .max = 8.0f },
+        },
+    .onStart =
+        [](GIAction& action) {
+            sMultiplier = action.params.Float("multiplier");
+
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sDamageHook);
+            sDamageHook = REGISTER_VB_SHOULD(VB_MULTIPLY_INFLICTED_DMG, {
+                // `should` is left alone: it carries Giant's Mask quarter-damage, which composes on top.
+                s32* damage = va_arg(args, s32*);
+                *damage = (s32)(*damage * sMultiplier);
+            });
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sDamageHook);
+            sDamageHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/DrunkLink.cpp
+++ b/mm/2s2h/GameInteractor/Actions/DrunkLink.cpp
@@ -1,0 +1,65 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+static HOOK_ID sInputHook = 0;
+static float sStrength = 40.0f;
+// A binary angle, so the phase wraps at the end of a cycle for free.
+static s16 sPhase = 0;
+static const s16 sPhaseStep = 0x10000 / (20 * 3); // one full sway every 3 seconds
+
+static s8 AddSway(s8 value, float sway) {
+    float swayed = value + sway;
+
+    // The total can leave the range an s8 stick can express.
+    if (swayed > 127.0f) {
+        return 127;
+    }
+    if (swayed < -127.0f) {
+        return -127;
+    }
+    return (s8)swayed;
+}
+
+// Sways the stick from side to side. OnPassPlayerInputs fires on a *copy* of the controller state,
+// so menus, shops and the ocarina are unaffected.
+static GIActions::Register drunkLinkAction({
+    .id = GI_ACTION_DRUNK_LINK,
+    .name = "drunkLink",
+    .displayName = "Drunk Link",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            // How far the sway pushes the stick, in stick units; 127 is a full deflection.
+            { .name = "strength", .type = GI_PARAM_FLOAT, .defaultValue = 40.0f, .min = 5.0f, .max = 127.0f },
+        },
+    .onStart =
+        [](GIAction& action) {
+            sStrength = action.params.Float("strength");
+            sPhase = 0;
+
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(sInputHook);
+            sInputHook =
+                GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPassPlayerInputs>([](Input* input) {
+                    sPhase += sPhaseStep;
+                    float sway = Math_SinS(sPhase) * sStrength;
+
+                    // `prev` is left alone: stamping this frame's phase onto last frame's stick
+                    // would describe a sway that never happened.
+                    input->cur.stick_x = AddSway(input->cur.stick_x, sway);
+                    input->rel.stick_x = AddSway(input->rel.stick_x, sway);
+                });
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(sInputHook);
+            sInputHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/EmptyWallet.cpp
+++ b/mm/2s2h/GameInteractor/Actions/EmptyWallet.cpp
@@ -1,0 +1,50 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+}
+
+// Drops the player's entire wallet on the floor as collectible rupees.
+static GIActions::Register emptyWalletAction({
+    .id = GI_ACTION_EMPTY_WALLET,
+    .name = "emptyWallet",
+    .displayName = "Empty Wallet",
+    .valence = GI_VALENCE_NEGATIVE,
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            int16_t currentRupees = gSaveContext.save.saveInfo.playerData.rupees;
+            if (currentRupees == 0) {
+                return;
+            }
+
+            Vec3f positional = GET_PLAYER(gPlayState)->actor.world.pos;
+            positional.y = GET_PLAYER(gPlayState)->actor.world.pos.y + 100.0f;
+
+            while (currentRupees > 0) {
+                Item00Type rupee = ITEM00_RUPEE_GREEN;
+                int16_t denomination = 1;
+                if (currentRupees >= 20) {
+                    rupee = ITEM00_RUPEE_RED;
+                    denomination = 20;
+                } else if (currentRupees >= 5) {
+                    rupee = ITEM00_RUPEE_BLUE;
+                    denomination = 5;
+                }
+
+                EnItem00* rupeeActor = (EnItem00*)Item_DropCollectible(gPlayState, &positional, rupee);
+                if (rupeeActor == NULL) {
+                    // Actor system is full; whatever didn't make it onto the floor stays in the wallet.
+                    break;
+                }
+                rupeeActor->actor.speed = Rand_CenteredFloat(5.0f);
+                rupeeActor->unk152 = 600; // Extending Time before Despawning
+
+                Rupees_ChangeBy(-denomination);
+                currentRupees -= denomination;
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Fog.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Fog.cpp
@@ -1,0 +1,64 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+// Below 950 the fullscreen fog filter is fully opaque -- a flat colour card, not fog.
+#define FOG_NEAR_CLEAREST ENV_FOGNEAR_MAX // 996
+#define FOG_NEAR_THICKEST 950
+
+// Rolled once per activation, so the fog settles on a colour rather than strobing.
+static u8 sColor[3] = { 128, 128, 128 };
+
+// Written as a delta through adjLightSettings: Environment_UpdateLights rebuilds lightCtx from
+// lightSettings + adjLightSettings after the queue ticks, so a direct write would be overwritten.
+static GIActions::Register fogAction({
+    .id = GI_ACTION_FOG,
+    .name = "fog",
+    .displayName = "Fog",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            // 0 leaves the scene's own draw distance alone; 1 is as thick as fog can get.
+            { .name = "intensity", .type = GI_PARAM_FLOAT, .defaultValue = 0.75f, .min = 0.0f, .max = 1.0f },
+        },
+    .onStart =
+        [](GIAction& action) {
+            sColor[0] = (u8)Rand_Next();
+            sColor[1] = (u8)Rand_Next();
+            sColor[2] = (u8)Rand_Next();
+        },
+    .onTick =
+        [](GIAction& action) {
+            if (gPlayState == NULL) {
+                return;
+            }
+            EnvironmentContext* envCtx = &gPlayState->envCtx;
+
+            s16 fogNear = FOG_NEAR_CLEAREST - (s16)((FOG_NEAR_CLEAREST - FOG_NEAR_THICKEST) *
+                                                    action.params.Float("intensity"));
+
+            envCtx->adjLightSettings.fogNear = fogNear - envCtx->lightSettings.fogNear;
+            for (int i = 0; i < 3; i++) {
+                envCtx->adjLightSettings.fogColor[i] = (s16)sColor[i] - envCtx->lightSettings.fogColor[i];
+            }
+        },
+    .onEnd =
+        [](GIAction& action) {
+            if (gPlayState == NULL) {
+                return;
+            }
+            EnvironmentContext* envCtx = &gPlayState->envCtx;
+
+            // Zero is the identity for a delta.
+            envCtx->adjLightSettings.fogNear = 0;
+            for (int i = 0; i < 3; i++) {
+                envCtx->adjLightSettings.fogColor[i] = 0;
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Freeze.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Freeze.cpp
@@ -1,0 +1,19 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+void func_80833B18(PlayState* play, Player* thisx, s32 arg2, f32 speed, f32 velocityY, s16 arg5,
+                   s32 invincibilityTimer);
+}
+
+static GIActions::Register freezeAction({
+    .id = GI_ACTION_FREEZE,
+    .name = "freeze",
+    .displayName = "Freeze",
+    .valence = GI_VALENCE_NEGATIVE,
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart = [](GIAction& action) { func_80833B18(gPlayState, GET_PLAYER(gPlayState), 3, 0, 0, 0, 0); },
+});

--- a/mm/2s2h/GameInteractor/Actions/GiveItem.cpp
+++ b/mm/2s2h/GameInteractor/Actions/GiveItem.cpp
@@ -1,0 +1,95 @@
+#include "Actions.h"
+
+#include <spdlog/spdlog.h>
+
+#include "2s2h/CustomItem/CustomItem.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64actor.h"
+#include "z64interface.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+}
+
+namespace {
+
+// Only one give-item is ever in flight (the action blocks the queue), so a single slot is enough.
+GIActions::GiveItemArgs inFlight = {};
+
+void GiveItemAction(Actor* actor, PlayState* play) {
+    Player* player = GET_PLAYER(play);
+
+    if (inFlight.giveItem != nullptr) {
+        inFlight.giveItem(actor, play);
+    }
+
+    if (inFlight.showGetItemCutscene && !(CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE)) {
+        player->actor.freezeTimer = 30;
+    }
+
+    GameInteractor::Instance->FinishBlocking(GI_STATUS_APPLIED);
+}
+
+void GiveItemDestroy(Actor* actor, PlayState* play) {
+    if (!(CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION)) {
+        // Scene torn down before pickup; requeue rather than swallow the item.
+        GameInteractor::Instance->RequeueBlocking();
+    }
+}
+
+} // namespace
+
+GIAction GIActions::GiveItem(GIActions::GiveItemArgs args) {
+    return GIAction{
+        .id = GI_ACTION_NONE,
+        .blocking = true,
+        .onStart =
+            [args](GIAction& action) {
+                Player* player = GET_PLAYER(gPlayState);
+
+                inFlight = args;
+
+                s16 flags = CustomItem::HIDE_TILL_OVERHEAD | CustomItem::KEEP_ON_PLAYER;
+
+                // If the player is climbing or in the air, deliver the item without a cutscene but
+                // freeze the player
+                if (!args.showGetItemCutscene ||
+                    (player->stateFlags1 & (PLAYER_STATE1_CHARGING_SPIN_ATTACK | PLAYER_STATE1_2000 |
+                                            PLAYER_STATE1_4000 | PLAYER_STATE1_40000 | PLAYER_STATE1_80000 |
+                                            PLAYER_STATE1_100000 | PLAYER_STATE1_200000 | PLAYER_STATE1_8000000)) ||
+                    (Player_GetExplosiveHeld(player) > PLAYER_EXPLOSIVE_NONE)) {
+
+                    flags |= CustomItem::GIVE_OVERHEAD;
+                } else {
+                    flags |= CustomItem::GIVE_ITEM_CUTSCENE;
+                }
+
+                EnItem00* enItem00 =
+                    CustomItem::Spawn(player->actor.world.pos.x, player->actor.world.pos.y, player->actor.world.pos.z,
+                                      0, flags, args.param, GiveItemAction, args.drawItem);
+                if (enItem00 == nullptr) {
+                    // Nothing will ever call FinishBlocking, so stop blocking or the queue wedges shut.
+                    SPDLOG_ERROR("[GameInteractor] Give-item couldn't spawn its item actor");
+                    action.blocking = false;
+                    return;
+                }
+                enItem00->actor.destroy = GiveItemDestroy;
+            },
+    };
+}
+
+// The remote-facing counterpart: no draw function, no pickup ceremony.
+static GIActions::Register giveItemAction({
+    .id = GI_ACTION_GIVE_ITEM,
+    .name = "giveItem",
+    .displayName = "Give Item",
+    .valence = GI_VALENCE_POSITIVE,
+    .schema =
+        {
+            // The item enum spans the whole byte short of ITEM_NONE (0xFF).
+            { .name = "itemId", .type = GI_PARAM_INT, .required = true, .min = 0.0f, .max = 254.0f },
+        },
+    .onStart = [](GIAction& action) { Item_Give(gPlayState, (u8)action.params.Int("itemId")); },
+});

--- a/mm/2s2h/GameInteractor/Actions/Health.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Health.cpp
@@ -1,0 +1,27 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+// The engine counts health in sixteenths of a heart; the param is in hearts.
+#define HEALTH_PER_HEART 16.0f
+
+static GIActions::Register healthAction({
+    .id = GI_ACTION_HEALTH,
+    .name = "health",
+    .displayName = "Health",
+    .valence = GI_VALENCE_NEUTRAL, // Covers both directions, so neither valence is honest.
+    .schema =
+        {
+            // Negative takes hearts away. 20 is the most the game allows.
+            { .name = "amount", .type = GI_PARAM_FLOAT, .required = true, .min = -20.0f, .max = 20.0f },
+        },
+    .onStart =
+        [](GIAction& action) {
+            // Health_ChangeBy applies the game's own rules: clamping, Double Defense, death at zero.
+            Health_ChangeBy(gPlayState, (s16)(action.params.Float("amount") * HEALTH_PER_HEART));
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Invincibility.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Invincibility.cpp
@@ -1,0 +1,31 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+// PLAYER_STATE3_400000 rather than invincibilityTimer: the timer caps at 127 frames and flashes
+// Link red; the flag is the same early-out with neither.
+static GIActions::Register invincibilityAction({
+    .id = GI_ACTION_INVINCIBILITY,
+    .name = "invincibility",
+    .displayName = "Invincibility",
+    .valence = GI_VALENCE_POSITIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    // Re-applied every tick so it survives the player being rebuilt by a transition.
+    .onTick =
+        [](GIAction&) {
+            if (Player* player = GIActions::PlayerOrNull()) {
+                player->stateFlags3 |= PLAYER_STATE3_400000;
+            }
+        },
+    .onEnd =
+        [](GIAction&) {
+            if (Player* player = GIActions::PlayerOrNull()) {
+                player->stateFlags3 &= ~PLAYER_STATE3_400000;
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Jinx.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Jinx.cpp
@@ -1,0 +1,27 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+}
+
+// Instant rather than timed: the game owns the jinxTimer countdown, so a timed action would race it.
+static GIActions::Register jinxAction({
+    .id = GI_ACTION_JINX,
+    .name = "jinx",
+    .displayName = "Jinx",
+    .valence = GI_VALENCE_NEGATIVE,
+    .schema =
+        {
+            // 20 units per second; the ceiling is what a u16 holds.
+            { .name = "length", .type = GI_PARAM_INT, .defaultValue = 20 * 60, .min = 1, .max = 65535 },
+        },
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            Actor_PlaySfx(&GET_PLAYER(gPlayState)->actor, NA_SE_EN_BUBLE_BITE);
+            gSaveContext.jinxTimer = static_cast<u16>(action.params.Int("length"));
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/KillLink.cpp
+++ b/mm/2s2h/GameInteractor/Actions/KillLink.cpp
@@ -1,0 +1,19 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static GIActions::Register killLinkAction({
+    .id = GI_ACTION_KILL_LINK,
+    .name = "killLink",
+    .displayName = "Kill Link",
+    .valence = GI_VALENCE_NEGATIVE,
+    .onStart =
+        [](GIAction& action) {
+            // Zeroing health rather than dealing damage, which invincibility would swallow.
+            gSaveContext.save.saveInfo.playerData.health = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Knockback.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Knockback.cpp
@@ -1,0 +1,47 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+}
+
+// Instant rather than timed: the bouncing ends when the player lands, not after a fixed duration.
+static GIActions::Register knockbackAction({
+    .id = GI_ACTION_KNOCKBACK,
+    .name = "knockback",
+    .displayName = "Knockback",
+    .valence = GI_VALENCE_NEGATIVE,
+    .schema =
+        {
+            { .name = "strength", .type = GI_PARAM_FLOAT, .defaultValue = 4.0f, .min = 1.0f, .max = 10.0f },
+        },
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            Player* player = GET_PLAYER(gPlayState);
+            float strength = action.params.Float("strength");
+
+            func_800B8D98(gPlayState, &player->actor, strength * 5, player->actor.world.rot.y + 0x8000, strength * 5);
+
+            static HOOK_ID knockbackBounceHook = 0;
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(knockbackBounceHook);
+            knockbackBounceHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(
+                ACTOR_PLAYER, [](Actor* actor) {
+                    Player* player = (Player*)actor;
+
+                    if (player->actor.bgCheckFlags & 0x08 && abs(player->speedXZ) > 15.0f) {
+                        player->yaw = ((player->actor.wallYaw - player->yaw) + player->actor.wallYaw) - 0x8000;
+                        Player_PlaySfx(player, NA_SE_PL_BODY_HIT);
+                    }
+
+                    if (player->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
+                        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(
+                            knockbackBounceHook);
+                    }
+                });
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/MirrorCamera.cpp
+++ b/mm/2s2h/GameInteractor/Actions/MirrorCamera.cpp
@@ -1,0 +1,25 @@
+#include "Actions.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+// The state cvar behind Mirrored World mode; read every frame, so flipping it takes effect immediately.
+#define CVAR_MIRRORED_WORLD_STATE "gModes.MirroredWorld.State"
+
+// Restored rather than cleared: a player running Mirrored World mode may already have it on.
+static int32_t sPreviousState = GIActions::Setting::ABSENT;
+
+// Reusing Mirrored World also gets inverted culling, the map, and flipped X controls for free.
+static GIActions::Register mirrorCameraAction({
+    .id = GI_ACTION_MIRROR_CAMERA,
+    .name = "mirrorCamera",
+    .displayName = "Mirror Camera",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .onStart =
+        [](GIAction&) {
+            sPreviousState = GIActions::Setting::Snapshot(CVAR_MIRRORED_WORLD_STATE);
+            CVarSetInteger(CVAR_MIRRORED_WORLD_STATE, 1);
+        },
+    .onEnd = [](GIAction&) { GIActions::Setting::Restore(CVAR_MIRRORED_WORLD_STATE, sPreviousState); },
+});

--- a/mm/2s2h/GameInteractor/Actions/MirrorLink.cpp
+++ b/mm/2s2h/GameInteractor/Actions/MirrorLink.cpp
@@ -1,0 +1,70 @@
+#include "Actions.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+// OPEN_DISPS/CLOSE_DISPS expand into this; without it they don't link from C++.
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static HOOK_ID sBeforeDrawHook = 0;
+static HOOK_ID sAfterDrawHook = 0;
+
+// A negative scale reverses triangle winding, so culling has to be inverted back for Link's draw.
+// Toggled against Mirrored World, which may already have the whole scene inverted.
+static void InvertPlayerCulling(bool duringPlayer) {
+    if (gPlayState == NULL) {
+        return;
+    }
+
+    bool worldMirrored = CVarGetInteger("gModes.MirroredWorld.State", 0);
+    bool invert = duringPlayer ? !worldMirrored : worldMirrored;
+
+    OPEN_DISPS(gPlayState->state.gfxCtx);
+
+    if (invert) {
+        gSPSetExtraGeometryMode(POLY_OPA_DISP++, G_EX_INVERT_CULLING);
+        gSPSetExtraGeometryMode(POLY_XLU_DISP++, G_EX_INVERT_CULLING);
+    } else {
+        gSPClearExtraGeometryMode(POLY_OPA_DISP++, G_EX_INVERT_CULLING);
+        gSPClearExtraGeometryMode(POLY_XLU_DISP++, G_EX_INVERT_CULLING);
+    }
+
+    CLOSE_DISPS(gPlayState->state.gfxCtx);
+}
+
+// Visual only -- collision comes from the player's cylinder, not actor.scale.
+static GIActions::Register mirrorLinkAction({
+    .id = GI_ACTION_MIRROR_LINK,
+    .name = "mirrorLink",
+    .displayName = "Mirror Link",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .exclusionGroup = GI_EXCLUSION_PLAYER_SCALE,
+    // The ShouldActorDraw/OnActorDraw pair brackets exactly the player's own display list.
+    .onStart =
+        [](GIAction&) {
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldActorDraw>(sBeforeDrawHook);
+            sBeforeDrawHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::ShouldActorDraw>(
+                ACTOR_PLAYER, [](Actor* actor, bool* should) { InvertPlayerCulling(true); });
+
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorDraw>(sAfterDrawHook);
+            sAfterDrawHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorDraw>(
+                ACTOR_PLAYER, [](Actor* actor) { InvertPlayerCulling(false); });
+        },
+    .onTick = [](GIAction&) { GIActions::PlayerScale::Set(-1.0f, 1.0f, 1.0f); },
+    .onEnd =
+        [](GIAction&) {
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldActorDraw>(sBeforeDrawHook);
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorDraw>(sAfterDrawHook);
+            sBeforeDrawHook = 0;
+            sAfterDrawHook = 0;
+            GIActions::PlayerScale::Reset();
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/MotionBlur.cpp
+++ b/mm/2s2h/GameInteractor/Actions/MotionBlur.cpp
@@ -1,0 +1,38 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+#include "regs.h"
+}
+
+// Restored rather than blanket-disabled: the game turns blur on itself for Goht and other set pieces.
+static s32 sPreviousEnabled = 0;
+static s32 sPreviousAlpha = 0;
+
+static GIActions::Register motionBlurAction({
+    .id = GI_ACTION_MOTION_BLUR,
+    .name = "motionBlur",
+    .displayName = "Motion Blur",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            // How much of the previous frame is kept; the game's own uses sit between 60 and 150.
+            { .name = "strength", .type = GI_PARAM_INT, .defaultValue = 180, .min = 1, .max = 255 },
+        },
+    .onStart =
+        [](GIAction& action) {
+            sPreviousEnabled = R_MOTION_BLUR_ENABLED;
+            sPreviousAlpha = R_MOTION_BLUR_ALPHA;
+        },
+    // Re-applied every tick: scene loads reset these registers.
+    .onTick = [](GIAction& action) { Play_EnableMotionBlur(action.params.Int("strength")); },
+    .onEnd =
+        [](GIAction& action) {
+            R_MOTION_BLUR_ALPHA = sPreviousAlpha;
+            R_MOTION_BLUR_ENABLED = sPreviousEnabled;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/PaperLink.cpp
+++ b/mm/2s2h/GameInteractor/Actions/PaperLink.cpp
@@ -1,0 +1,14 @@
+#include "Actions.h"
+
+// Visual only -- collision comes from the player's cylinder, not actor.scale.
+static GIActions::Register paperLinkAction({
+    .id = GI_ACTION_PAPER_LINK,
+    .name = "paperLink",
+    .displayName = "Paper Link",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .exclusionGroup = GI_EXCLUSION_PLAYER_SCALE,
+    .onTick = [](GIAction& action) { GIActions::PlayerScale::Set(0.1f, 1.0f, 1.0f); },
+    .onEnd = [](GIAction& action) { GIActions::PlayerScale::Reset(); },
+});

--- a/mm/2s2h/GameInteractor/Actions/RandomSkybox.cpp
+++ b/mm/2s2h/GameInteractor/Actions/RandomSkybox.cpp
@@ -1,0 +1,69 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static const uint32_t sShiftInterval = 20 * 4; // How long one colour takes to fade into the next.
+// Not a param: full opacity paints the sky out into a flat colour card rather than tinting it.
+static const u8 sFilterAlpha = 100;
+
+static u8 sFrom[3] = { 255, 0, 255 };
+static u8 sTo[3] = { 0, 255, 255 };
+
+static void RollColor(u8 color[3]) {
+    color[0] = (u8)Rand_Next();
+    color[1] = (u8)Rand_Next();
+    color[2] = (u8)Rand_Next();
+}
+
+// customSkyboxFilter/skyboxFilterColor are a filter the game can draw but never uses, so nothing
+// fights over them. Environment_Init clears them per scene load, hence re-applying each tick.
+static GIActions::Register randomSkyboxAction({
+    .id = GI_ACTION_RANDOM_SKYBOX,
+    .name = "randomSkybox",
+    .displayName = "Random Skybox",
+    .valence = GI_VALENCE_NEUTRAL,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .onStart =
+        [](GIAction& action) {
+            RollColor(sFrom);
+            RollColor(sTo);
+        },
+    .onTick =
+        [](GIAction& action) {
+            if (gPlayState == NULL) {
+                return;
+            }
+
+            uint32_t phase = action.elapsed % sShiftInterval;
+            // elapsed 0 still has onStart's pair.
+            if (phase == 0 && action.elapsed > 0) {
+                sFrom[0] = sTo[0];
+                sFrom[1] = sTo[1];
+                sFrom[2] = sTo[2];
+                RollColor(sTo);
+            }
+
+            float t = (float)phase / sShiftInterval;
+            EnvironmentContext* envCtx = &gPlayState->envCtx;
+
+            envCtx->customSkyboxFilter = true;
+            for (int i = 0; i < 3; i++) {
+                float from = sFrom[i];
+                float to = sTo[i];
+                envCtx->skyboxFilterColor[i] = (u8)(from + ((to - from) * t));
+            }
+            envCtx->skyboxFilterColor[3] = sFilterAlpha;
+        },
+    .onEnd =
+        [](GIAction& action) {
+            if (gPlayState == NULL) {
+                return;
+            }
+            gPlayState->envCtx.customSkyboxFilter = false;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/RandomWind.cpp
+++ b/mm/2s2h/GameInteractor/Actions/RandomWind.cpp
@@ -1,0 +1,49 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+// How long the wind holds a direction before picking a new one.
+static const uint32_t sRerollInterval = 20 * 2; // 2 seconds
+static s16 sWindYaw = 0;
+
+// windSpeed/windAngleX/windAngleY are the fields Obj_Wind uses, so the player's own decay and
+// stagger reactions come free.
+static GIActions::Register randomWindAction({
+    .id = GI_ACTION_RANDOM_WIND,
+    .name = "randomWind",
+    .displayName = "Random Wind",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            // Scaled by form on the way in: Deku catches the most wind at 1.5x, Goron the least at 0.6x.
+            { .name = "strength", .type = GI_PARAM_FLOAT, .defaultValue = 6.0f, .min = 1.0f, .max = 20.0f },
+        },
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onTick =
+        [](GIAction& action) {
+            Player* player = GIActions::PlayerOrNull();
+            if (player == NULL) {
+                return;
+            }
+
+            if (action.elapsed % sRerollInterval == 0) {
+                sWindYaw = (s16)Rand_Next();
+            }
+
+            player->windSpeed = action.params.Float("strength");
+            player->windAngleX = 0; // Pitch: level with the ground. 0x4000 would blow straight up.
+            player->windAngleY = sWindYaw;
+        },
+    .onEnd =
+        [](GIAction&) {
+            if (Player* player = GIActions::PlayerOrNull()) {
+                player->windSpeed = 0.0f;
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/RandomizeCosmetics.cpp
+++ b/mm/2s2h/GameInteractor/Actions/RandomizeCosmetics.cpp
@@ -1,0 +1,13 @@
+#include "Actions.h"
+
+// Not declared in CosmeticEditor.h, so there's nothing to include.
+void CosmeticEditorRandomizeAllElements();
+
+// Persistent rather than timed: it writes the same cvars the Cosmetics Editor does; there's no undo.
+static GIActions::Register randomizeCosmeticsAction({
+    .id = GI_ACTION_RANDOMIZE_COSMETICS,
+    .name = "randomizeCosmetics",
+    .displayName = "Randomize Cosmetics",
+    .valence = GI_VALENCE_NEUTRAL,
+    .onStart = [](GIAction& action) { CosmeticEditorRandomizeAllElements(); },
+});

--- a/mm/2s2h/GameInteractor/Actions/ReverseControls.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ReverseControls.cpp
@@ -1,0 +1,45 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+static HOOK_ID sInputHook = 0;
+
+static s8 NegateStick(s8 value) {
+    // Negating -128 would wrap straight back to -128.
+    return value == -128 ? 127 : -value;
+}
+
+// OnPassPlayerInputs fires on a *copy* of the controller state, so menus, shops and the ocarina
+// are unaffected.
+static GIActions::Register reverseControlsAction({
+    .id = GI_ACTION_REVERSE_CONTROLS,
+    .name = "reverseControls",
+    .displayName = "Reverse Controls",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .onStart =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(sInputHook);
+            sInputHook =
+                GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPassPlayerInputs>([](Input* input) {
+                    // `press` is left alone: its x/y hold a delta, not a stick position.
+                    OSContPad* pads[] = { &input->cur, &input->prev, &input->rel };
+
+                    for (OSContPad* pad : pads) {
+                        pad->stick_x = NegateStick(pad->stick_x);
+                        pad->stick_y = NegateStick(pad->stick_y);
+                    }
+                });
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(sInputHook);
+            sInputHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/Rupees.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Rupees.cpp
@@ -1,0 +1,24 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static GIActions::Register rupeesAction({
+    .id = GI_ACTION_RUPEES,
+    .name = "rupees",
+    .displayName = "Rupees",
+    .valence = GI_VALENCE_NEUTRAL, // Covers both directions, so neither valence is honest.
+    .schema =
+        {
+            // Negative takes rupees away; 999 is the largest wallet.
+            { .name = "amount", .type = GI_PARAM_INT, .required = true, .min = -999, .max = 999 },
+        },
+    .onStart =
+        [](GIAction& action) {
+            // Rupees_ChangeBy nudges an accumulator that stops on its own at the wallet cap or zero.
+            Rupees_ChangeBy((s16)action.params.Int("amount"));
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/ScaleLink.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ScaleLink.cpp
@@ -1,0 +1,22 @@
+#include "Actions.h"
+
+static GIActions::Register scaleLinkAction({
+    .id = GI_ACTION_SCALE_LINK,
+    .name = "scaleLink",
+    .displayName = "Scale Link",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .exclusionGroup = GI_EXCLUSION_PLAYER_SCALE,
+    .schema =
+        {
+            // Above 1.0 makes Link bigger; past the ceiling he stops fitting through doorways.
+            { .name = "scale", .type = GI_PARAM_FLOAT, .defaultValue = 0.4f, .min = 0.05f, .max = 3.0f },
+        },
+    .onTick =
+        [](GIAction& action) {
+            float scale = action.params.Float("scale");
+            GIActions::PlayerScale::Set(scale, scale, scale);
+        },
+    .onEnd = [](GIAction&) { GIActions::PlayerScale::Reset(); },
+});

--- a/mm/2s2h/GameInteractor/Actions/Shock.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Shock.cpp
@@ -1,0 +1,25 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+void func_80833B18(PlayState* play, Player* thisx, s32 arg2, f32 speed, f32 velocityY, s16 arg5,
+                   s32 invincibilityTimer);
+}
+
+static GIActions::Register shockAction({
+    .id = GI_ACTION_SHOCK,
+    .name = "shock",
+    .displayName = "Shock",
+    .valence = GI_VALENCE_NEGATIVE,
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            Player* player = GET_PLAYER(gPlayState);
+
+            player->actor.colChkInfo.damage = 16;
+            func_80833B18(gPlayState, player, 4, 0, 0, 0, 0);
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/ShowMessage.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ShowMessage.cpp
@@ -1,0 +1,14 @@
+#include "Actions.h"
+
+#include "2s2h/CustomMessage/CustomMessage.h"
+
+static GIActions::Register showMessageAction({
+    .id = GI_ACTION_SHOW_MESSAGE,
+    .name = "showMessage",
+    .displayName = "Show Message",
+    .schema =
+        {
+            { .name = "text", .type = GI_PARAM_STRING, .required = true },
+        },
+    .onStart = [](GIAction& action) { CustomMessage::StartTextbox(action.params.String("text")); },
+});

--- a/mm/2s2h/GameInteractor/Actions/ShowTitleCard.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ShowTitleCard.cpp
@@ -1,0 +1,48 @@
+#include "Actions.h"
+
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static HOOK_ID sHudRestoreHook = 0;
+
+// Message_DisplaySceneTitleCard hides the HUD but never restores it -- En_Test4 does that itself.
+static void RestoreHudWhenCardEnds() {
+    GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameStateUpdate>(sHudRestoreHook);
+    sHudRestoreHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateUpdate>([]() {
+        // A transition tears the message down without ever reaching MSGMODE_NONE.
+        if (gPlayState != NULL && gPlayState->msgCtx.msgMode != MSGMODE_NONE) {
+            return;
+        }
+
+        // Interface_SetHudVisibility ignores a no-op change, so the idle assignment is what makes it take.
+        gSaveContext.hudVisibility = HUD_VISIBILITY_IDLE;
+        Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
+
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameStateUpdate>(sHudRestoreHook);
+        sHudRestoreHook = 0;
+    });
+}
+
+// The card is addressed by textId, so CUSTOM_MESSAGE_ID routes it through CustomMessage. The id
+// must sit outside 0x1BB2..0x1BB6, the Dawn/Night cards' taller layout.
+static GIActions::Register showTitleCardAction({
+    .id = GI_ACTION_SHOW_TITLE_CARD,
+    .name = "showTitleCard",
+    .displayName = "Show Title Card",
+    .schema =
+        {
+            { .name = "text", .type = GI_PARAM_STRING, .required = true },
+        },
+    .onStart =
+        [](GIAction& action) {
+            CustomMessage::SetActiveCustomMessage(action.params.String("text"));
+            Message_DisplaySceneTitleCard(gPlayState, CUSTOM_MESSAGE_ID);
+            RestoreHudWhenCardEnds();
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/ShrinkScreen.cpp
+++ b/mm/2s2h/GameInteractor/Actions/ShrinkScreen.cpp
@@ -1,0 +1,56 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+// Drives gSaveContext.screenScale/screenScaleFlag, the fields behind the game's own end-of-day
+// framebuffer shrink (1000 = full frame, lower = smaller).
+
+// Frames spent easing in at the start and back out at the end.
+#define SHRINK_RAMP_FRAMES 15
+
+static GIActions::Register shrinkScreenAction({
+    .id = GI_ACTION_SHRINK_SCREEN,
+    .name = "shrinkScreen",
+    .displayName = "Shrink Screen",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            // The fraction of the screen the frame gives up; the 0.9 cap keeps it playable.
+            { .name = "intensity", .type = GI_PARAM_FLOAT, .defaultValue = 0.4f, .min = 0.05f, .max = 0.9f },
+        },
+    .onTick =
+        [](GIAction& action) {
+            if (gPlayState == NULL) {
+                return;
+            }
+
+            float target = 1000.0f - (1000.0f * action.params.Float("intensity"));
+
+            // Ease in, hold, ease back out. duration is guarded before the subtraction so it can't
+            // underflow.
+            float progress;
+            uint32_t elapsed = action.elapsed;
+            uint32_t duration = action.duration;
+            if (elapsed < SHRINK_RAMP_FRAMES) {
+                progress = (float)elapsed / SHRINK_RAMP_FRAMES;
+            } else if (duration > 2 * SHRINK_RAMP_FRAMES && elapsed > duration - SHRINK_RAMP_FRAMES) {
+                progress = (float)(duration - elapsed) / SHRINK_RAMP_FRAMES;
+            } else {
+                progress = 1.0f;
+            }
+
+            gSaveContext.screenScale = 1000.0f - ((1000.0f - target) * progress);
+            gSaveContext.screenScaleFlag = gSaveContext.screenScale < 1000.0f;
+        },
+    // No play-state guard: gSaveContext is a global, so the write is valid even after a save load.
+    .onEnd =
+        [](GIAction& action) {
+            gSaveContext.screenScaleFlag = false;
+            gSaveContext.screenScale = 1000.0f;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/SkipTime.cpp
+++ b/mm/2s2h/GameInteractor/Actions/SkipTime.cpp
@@ -1,0 +1,96 @@
+#include "Actions.h"
+
+#include "2s2h/ShipUtils.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+#include "overlays/actors/ovl_En_Time_Tag/z_en_time_tag.h"
+void EnTimeTag_KickOut_Transition(EnTimeTag* enTimeTag, PlayState* play);
+}
+
+extern void UpdateGameTime(u16 gameTime);
+
+static GIActions::Register skipTimeAction({
+    .id = GI_ACTION_SKIP_TIME,
+    .name = "skipTime",
+    .displayName = "Skip Time",
+    .valence = GI_VALENCE_NEGATIVE,
+    .schema =
+        {
+            // Game-clock units, not frames: DAY_LENGTH (0x10000) is a full day.
+            { .name = "length", .type = GI_PARAM_INT, .defaultValue = 4000, .min = 1, .max = 65535 },
+        },
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            u16 timeSkipInterval = static_cast<u16>(action.params.Int("length"));
+            u16 previous_time = gSaveContext.save.time;
+            u16 new_time = gSaveContext.save.time + timeSkipInterval;
+
+            // Normalised to 6AM so the test holds for any length; a raw MORNING_TIME comparison
+            // misses skips that wrap past 0xFFFF.
+            bool crossedIntoNewDay = (u32)ZERO_DAY_START(previous_time) + timeSkipInterval >= DAY_LENGTH;
+
+            if (crossedIntoNewDay) {
+                // Handles case where Night -> Day
+                if (gSaveContext.save.day != 3) {
+                    gSaveContext.save.day++;
+                    gSaveContext.save.eventDayCount++;
+                    UpdateGameTime(new_time);
+                    Interface_NewDay(gPlayState, CURRENT_DAY);
+                    // Load environment values for new day
+                    Environment_NewDay(&gPlayState->envCtx);
+                    // Environment_NewDay only picks the skybox; without this Day 2's rain follows into Day 3.
+                    gWeatherMode = WEATHER_MODE_CLEAR;
+                    gPlayState->envCtx.lightningState = LIGHTNING_OFF;
+                } else {
+                    // Handles Moonfall case, prevents skipping past it by setting time right before
+                    // Moonfall.
+                    UpdateGameTime(MORNING_TIME - (timeSkipInterval / 10));
+                }
+            } else {
+                // Every other case
+                UpdateGameTime(new_time);
+            }
+
+            TransitionFade_SetColor(&gPlayState->unk_18E48, 0x000000);
+            R_TRANS_FADE_FLASH_ALPHA_STEP = -1;
+            Player_PlaySfx(GET_PLAYER(gPlayState), NA_SE_SY_TRANSFORM_MASK_FLASH);
+
+            // Handle kickouts, if needed
+            EnTimeTag* enTimeTag = (EnTimeTag*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
+                                                                ACTOR_EN_TIME_TAG, ACTORCAT_ITEMACTION, 99999.9f);
+            if (enTimeTag == nullptr) {
+                return;
+            }
+
+            TimeTagType timeTagType = (TimeTagType)TIMETAG_GET_TYPE(&enTimeTag->actor);
+            if (timeTagType != TIMETAG_KICKOUT_DOOR && timeTagType < TIMETAG_KICKOUT_FINAL_HOURS) {
+                return;
+            }
+
+            s16 kickoutHour = TIMETAG_KICKOUT_HOUR(&enTimeTag->actor);
+            s16 kickoutMinute = TIMETAG_KICKOUT_MINUTE(&enTimeTag->actor);
+            s32 kickoutTime = CLOCK_TIME(kickoutHour, kickoutMinute);
+            kickoutTime = ZERO_DAY_START(kickoutTime);
+            previous_time = ZERO_DAY_START(previous_time);
+            new_time = ZERO_DAY_START(new_time);
+
+            // If we were here before the kickout time, and now it's after, then get out of my house
+            if (previous_time <= kickoutTime && new_time >= kickoutTime) {
+                // Unless this is the Stock Pot Inn and the room key is obtained. Asked through the
+                // VB hook so rando can answer with its inf flag.
+                bool hasRoomKey =
+                    GameInteractor_Should(VB_CHECK_FOR_ROOM_KEY, INV_CONTENT(ITEM_ROOM_KEY) == ITEM_ROOM_KEY);
+                if (!(gPlayState->sceneId == SCENE_YADOYA && hasRoomKey)) {
+                    // This comes from EnTimeTag_KickOut_WaitForTime
+                    Player_SetCsActionWithHaltedActors(gPlayState, &enTimeTag->actor, PLAYER_CSACTION_WAIT);
+                    Message_StartTextbox(gPlayState, 0x1883 + TIMETAG_KICKOUT_GET_TEXT(&enTimeTag->actor), NULL);
+                    enTimeTag->actionFunc = EnTimeTag_KickOut_Transition;
+                }
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/SlipperyFloor.cpp
+++ b/mm/2s2h/GameInteractor/Actions/SlipperyFloor.cpp
@@ -1,0 +1,38 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+// Not in any header, but it has external linkage in z_player.c.
+extern FloorType sPlayerFloorType;
+}
+
+static HOOK_ID sFloorHook = 0;
+
+// Ice is a branch keyed on the floor under Link being FLOOR_TYPE_5; Player_ProcessSceneCollision
+// restores the true floor later in the same update. Written from ShouldActorUpdate rather than
+// onTick, which runs after the player updates -- too late for a value that doesn't survive the frame.
+static GIActions::Register slipperyFloorAction({
+    .id = GI_ACTION_SLIPPERY_FLOOR,
+    .name = "slipperyFloor",
+    .displayName = "Slippery Floor",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    // On a horse the player skips the ice branch entirely, so this would silently do nothing.
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldActorUpdate>(sFloorHook);
+            sFloorHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::ShouldActorUpdate>(
+                ACTOR_PLAYER, [](Actor* actor, bool* should) { sPlayerFloorType = FLOOR_TYPE_5; });
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldActorUpdate>(sFloorHook);
+            sFloorHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/SpawnActor.cpp
+++ b/mm/2s2h/GameInteractor/Actions/SpawnActor.cpp
@@ -1,0 +1,63 @@
+#include "Actions.h"
+
+#include "2s2h/NameTag/NameTag.h"
+
+extern "C" {
+#include "z64.h"
+#include "z64math.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+}
+
+static GIActions::Register spawnActorAction({
+    .id = GI_ACTION_SPAWN_ACTOR,
+    .name = "spawnActor",
+    .displayName = "Spawn Actor",
+    .schema =
+        {
+            { .name = "actorId", .type = GI_PARAM_INT, .required = true, .min = 0.0f, .max = ACTOR_ID_MAX - 1.0f },
+            { .name = "posX", .type = GI_PARAM_FLOAT },
+            { .name = "posY", .type = GI_PARAM_FLOAT },
+            { .name = "posZ", .type = GI_PARAM_FLOAT },
+            { .name = "rotX", .type = GI_PARAM_INT },
+            { .name = "rotY", .type = GI_PARAM_INT },
+            { .name = "rotZ", .type = GI_PARAM_INT },
+            { .name = "params", .type = GI_PARAM_INT },
+            // Coordinates relative to the player: x+ is to their right, y+ up, z+ in front.
+            { .name = "relativeCoords", .type = GI_PARAM_BOOL },
+            // Optional label drawn above the spawned actor.
+            { .name = "nametag", .type = GI_PARAM_STRING },
+        },
+    .onStart =
+        [](GIAction& action) {
+            Player* player = GET_PLAYER(gPlayState);
+            f32 posX = action.params.Float("posX");
+            f32 posY = action.params.Float("posY");
+            f32 posZ = action.params.Float("posZ");
+            s16 rotX = (s16)action.params.Int("rotX");
+            s16 rotY = (s16)action.params.Int("rotY");
+            s16 rotZ = (s16)action.params.Int("rotZ");
+            Actor* actor;
+
+            if (action.params.Bool("relativeCoords")) {
+                // Math_SinS/CosS, not sinf/cosf: rot.y is a binary angle, not radians.
+                f32 s = Math_SinS(player->actor.world.rot.y);
+                f32 c = Math_CosS(player->actor.world.rot.y);
+                f32 x = posX * c - posZ * s;
+                f32 z = posX * s + posZ * c;
+                actor = Actor_Spawn(&gPlayState->actorCtx, gPlayState, (s16)action.params.Int("actorId"),
+                                    player->actor.world.pos.x + x, player->actor.world.pos.y + posY,
+                                    player->actor.world.pos.z + z, 0, rotY + player->actor.world.rot.y, 0,
+                                    action.params.Int("params"));
+            } else {
+                actor = Actor_Spawn(&gPlayState->actorCtx, gPlayState, (s16)action.params.Int("actorId"), posX, posY,
+                                    posZ, rotX, rotY, rotZ, action.params.Int("params"));
+            }
+
+            const std::string& nametag = action.params.String("nametag");
+            if (actor != NULL && !nametag.empty()) {
+                NameTag_RegisterForActor(actor, nametag.c_str());
+            }
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/SpawnLikeLike.cpp
+++ b/mm/2s2h/GameInteractor/Actions/SpawnLikeLike.cpp
@@ -1,0 +1,38 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "functions.h"
+#include "macros.h"
+}
+
+static GIActions::Register spawnLikeLikeAction({
+    .id = GI_ACTION_SPAWN_LIKE_LIKE,
+    .name = "spawnLikeLike",
+    .displayName = "Spawn Like Like",
+    .valence = GI_VALENCE_NEGATIVE,
+    .canApply = GIActions::Gates::NotOnHorse,
+    .onStart =
+        [](GIAction& action) {
+            Player* player = GET_PLAYER(gPlayState);
+
+            Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_RR, player->actor.world.pos.x,
+                        player->actor.world.pos.y, player->actor.world.pos.z, 0, 0, 0, 1);
+        },
+});
+
+// Most scenes don't load OBJECT_RR, so without this the spawn above quietly does nothing.
+void RegisterSpawnLikeLikeObjectDependency() {
+    REGISTER_VB_SHOULD(VB_ENABLE_OBJECT_DEPENDENCY, {
+        ObjectId objectId = (ObjectId)va_arg(args, int);
+        if (objectId == OBJECT_RR || objectId == OBJECT_GI_SHIELD_2) {
+            *should = false;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSpawnLikeLikeObjectDependency);

--- a/mm/2s2h/GameInteractor/Actions/Speed.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Speed.cpp
@@ -1,0 +1,56 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+// File statics because REGISTER_VB_SHOULD expands to a captureless lambda.
+static float sMultiplier = 1.0f;
+static HOOK_ID sWalkHook = 0;
+static HOOK_ID sSwimHook = 0;
+
+// Scales the speed *target* before vanilla's stepping; multiplying speedXZ itself would compound.
+static GIActions::Register speedAction({
+    .id = GI_ACTION_SPEED,
+    .name = "speed",
+    .displayName = "Speed",
+    .valence = GI_VALENCE_NEUTRAL,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .schema =
+        {
+            // Below 1.0 slows Link down, above speeds him up.
+            { .name = "multiplier", .type = GI_PARAM_FLOAT, .required = true, .min = 0.1f, .max = 3.0f },
+        },
+    .onStart =
+        [](GIAction& action) {
+            sMultiplier = action.params.Float("multiplier");
+
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sWalkHook);
+            sWalkHook = REGISTER_VB_SHOULD(VB_SPEED_MODIFIER_WALK, {
+                f32* speedTarget = va_arg(args, f32*);
+                *speedTarget *= sMultiplier;
+            });
+
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sSwimHook);
+            sSwimHook = REGISTER_VB_SHOULD(VB_SPEED_MODIFIER_SWIM, {
+                va_arg(args, f32*); // incrStep
+                f32* maxSpeed = va_arg(args, f32*);
+                va_arg(args, f32*); // speed
+                f32* speedTarget = va_arg(args, f32*);
+
+                *maxSpeed *= sMultiplier;
+                *speedTarget *= sMultiplier;
+            });
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sWalkHook);
+            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(sSwimHook);
+            sWalkHook = 0;
+            sSwimHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/Actions/SquishLink.cpp
+++ b/mm/2s2h/GameInteractor/Actions/SquishLink.cpp
@@ -1,0 +1,19 @@
+#include "Actions.h"
+
+// Squashes Link vertically and spreads him to match, so he reads as a pancake.
+static GIActions::Register squishLinkAction({
+    .id = GI_ACTION_SQUISH_LINK,
+    .name = "squishLink",
+    .displayName = "Squish Link",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .exclusionGroup = GI_EXCLUSION_PLAYER_SCALE,
+    .onTick =
+        [](GIAction& action) {
+            float intensity = 0.3f;
+            float spread = 2.0f - intensity;
+            GIActions::PlayerScale::Set(spread, intensity, spread);
+        },
+    .onEnd = [](GIAction& action) { GIActions::PlayerScale::Reset(); },
+});

--- a/mm/2s2h/GameInteractor/Actions/Transition.cpp
+++ b/mm/2s2h/GameInteractor/Actions/Transition.cpp
@@ -1,0 +1,41 @@
+#include "Actions.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+#include "macros.h"
+}
+
+static GIActions::Register transitionAction({
+    .id = GI_ACTION_TRANSITION,
+    .name = "transition",
+    .displayName = "Teleport",
+    .schema =
+        {
+            { .name = "entrance", .type = GI_PARAM_INT, .required = true, .min = 0.0f, .max = 65535.0f },
+            { .name = "cutsceneIndex", .type = GI_PARAM_INT },
+            { .name = "transitionTrigger", .type = GI_PARAM_INT, .defaultValue = (int32_t)TRANS_TRIGGER_START },
+            { .name = "transitionType", .type = GI_PARAM_INT, .defaultValue = (int32_t)TRANS_TYPE_FADE_BLACK },
+        },
+    .onStart =
+        [](GIAction& action) {
+            gPlayState->nextEntrance = (u16)action.params.Int("entrance");
+            gSaveContext.nextCutsceneIndex = (u16)action.params.Int("cutsceneIndex");
+            gPlayState->transitionTrigger = (s8)action.params.Int("transitionTrigger");
+            gPlayState->transitionType = (u8)action.params.Int("transitionType");
+        },
+});
+
+GIAction GIActions::Transition(GIActions::TransitionArgs args) {
+    const GIActions::Definition* definition = GIActions::Get(GI_ACTION_TRANSITION);
+
+    // Every field is typed at the call site and every value fits its spec, so this can't fail.
+    return definition
+        ->Build({
+            { "entrance", (int32_t)args.entrance },
+            { "cutsceneIndex", (int32_t)args.cutsceneIndex },
+            { "transitionTrigger", (int32_t)args.transitionTrigger },
+            { "transitionType", (int32_t)args.transitionType },
+        })
+        .value_or(GIAction{});
+}

--- a/mm/2s2h/GameInteractor/Actions/UpsideDownCamera.cpp
+++ b/mm/2s2h/GameInteractor/Actions/UpsideDownCamera.cpp
@@ -1,0 +1,35 @@
+#include "Actions.h"
+
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "variables.h"
+}
+
+static HOOK_ID sCameraHook = 0;
+
+// Half a turn of roll, which lands the up vector exactly negated.
+#define UPSIDE_DOWN_ROLL 0x8000
+
+// A rotation, not a reflection, so there's no culling to invert; the HUD stays upright.
+static GIActions::Register upsideDownCameraAction({
+    .id = GI_ACTION_UPSIDE_DOWN_CAMERA,
+    .name = "upsideDownCamera",
+    .displayName = "Upside Down Camera",
+    .valence = GI_VALENCE_NEGATIVE,
+    .defaultDuration = 20 * 30, // 30 seconds
+    .stacking = GI_STACK_REFRESH,
+    .exclusionGroup = GI_EXCLUSION_CAMERA_ROLL,
+    .onStart =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::AfterCameraUpdate>(sCameraHook);
+            sCameraHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterCameraUpdate>(
+                [](Camera* camera) { GIActions::CameraRoll::Apply(camera, UPSIDE_DOWN_ROLL); });
+        },
+    .onEnd =
+        [](GIAction& action) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::AfterCameraUpdate>(sCameraHook);
+            sCameraHook = 0;
+        },
+});

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -1,10 +1,10 @@
 #include "GameInteractor.h"
-#include <variant>
 #include <spdlog/spdlog.h>
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/BenPort.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
 extern "C" {
 #include "z64actor.h"
@@ -393,12 +393,6 @@ int GameInteractor_InvertControl(GIInvertType type) {
         }
     }
 
-    /*
-    if (CrowdControl::State::InvertedInputs) {
-        result *= -1;
-    }
-    */
-
     return result;
 }
 
@@ -484,118 +478,263 @@ uint32_t GameInteractor_CustomOcarinaControls(Input* input) {
     return result;
 }
 
-void ProcessEvents(Actor* actor) {
+static void Complete(GIAction& action, GIActionStatus status) {
+    if (action.onComplete) {
+        action.onComplete(status);
+    }
+}
+
+void GameInteractor::Queue(GIAction action) {
+    actions.push_back(std::move(action));
+}
+
+// The gates that apply to every action, regardless of what it does. These are the conditions
+// under which the game simply cannot accept anything right now; they are never permanent, so they
+// only ever defer.
+GIActionAvailability GameInteractor::CanProcessActions() {
+    if (gPlayState == NULL) {
+        return GI_AVAILABILITY_NOT_YET;
+    }
+
     Player* player = GET_PLAYER(gPlayState);
+    if (player == NULL) {
+        return GI_AVAILABILITY_NOT_YET;
+    }
 
-    // If the player has a message active, stop
+    // A message is on screen
     if (gPlayState->msgCtx.msgMode != 0) {
-        return;
+        return GI_AVAILABILITY_NOT_YET;
     }
 
-    // If the player is in a blocking cutscene, stop
     if (Player_InBlockingCsMode(gPlayState, player)) {
-        return;
+        return GI_AVAILABILITY_NOT_YET;
     }
 
-    // If player is dead, stop
     if (player->stateFlags1 & PLAYER_STATE1_DEAD) {
-        return;
+        return GI_AVAILABILITY_NOT_YET;
     }
 
-    // If there is an event active, stop
-    const auto& currentEvent = GameInteractor::Instance->currentEvent;
-    if (auto e = std::get_if<GIEventNone>(&currentEvent)) {
-        // no-op
-    } else {
-        return;
-    }
+    return GI_AVAILABILITY_READY;
+}
 
-    // If there are no events that need to happen, stop
-    if (GameInteractor::Instance->events.empty()) {
-        return;
-    }
-
-    GameInteractor::Instance->currentEvent = GameInteractor::Instance->events.front();
-    const auto& nextEvent = GameInteractor::Instance->currentEvent;
-
-    if (auto e = std::get_if<GIEventGiveItem>(&nextEvent)) {
-        EnItem00* enItem00;
-
-        s16 flags = CustomItem::HIDE_TILL_OVERHEAD | CustomItem::KEEP_ON_PLAYER;
-
-        // If the player is climbing or in the air, deliver the item without a cutscene but freeze the player
-        if (!e->showGetItemCutscene ||
-            (player->stateFlags1 &
-             (PLAYER_STATE1_CHARGING_SPIN_ATTACK | PLAYER_STATE1_2000 | PLAYER_STATE1_4000 | PLAYER_STATE1_40000 |
-              PLAYER_STATE1_80000 | PLAYER_STATE1_100000 | PLAYER_STATE1_200000 | PLAYER_STATE1_8000000)) ||
-            (Player_GetExplosiveHeld(player) > PLAYER_EXPLOSIVE_NONE)) {
-
-            flags |= CustomItem::GIVE_OVERHEAD;
-        } else {
-            flags |= CustomItem::GIVE_ITEM_CUTSCENE;
+const GIAction* GameInteractor::FindActive(GIActionId id) {
+    for (const auto& active : activeActions) {
+        if (active.id == id) {
+            return &active;
         }
+    }
+    return nullptr;
+}
 
-        enItem00 = CustomItem::Spawn(
-            player->actor.world.pos.x, player->actor.world.pos.y, player->actor.world.pos.z, 0, flags, e->param,
-            [](Actor* actor, PlayState* play) {
-                Player* player = GET_PLAYER(gPlayState);
-                const auto& nextEvent = GameInteractor::Instance->currentEvent;
-                if (auto e = std::get_if<GIEventGiveItem>(&nextEvent)) {
-                    e->giveItem(actor, play);
-                    if (e->showGetItemCutscene && !(CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE)) {
-                        player->actor.freezeTimer = 30;
-                    }
-                    GameInteractor::Instance->currentEvent = GIEventNone{};
+GIActionAvailability GameInteractor::GetAvailability(const GIAction& action) {
+    if (action.canApply) {
+        GIActionAvailability availability = action.canApply(action);
+        if (availability != GI_AVAILABILITY_READY) {
+            return availability;
+        }
+    }
+
+    // A timed action that's already running decides for itself what a second action means.
+    if (action.duration > 0 && action.id != GI_ACTION_NONE && IsActionActive(action.id)) {
+        const GIActions::Definition* definition = GIActions::Get(action.id);
+        if (definition == nullptr || definition->stacking == GI_STACK_QUEUE) {
+            return GI_AVAILABILITY_NOT_YET;
+        }
+    }
+
+    // Two different actions writing the same field wait for each other the same way two requests
+    // for one action do. The action names its own group, so this needs no list of who conflicts.
+    const GIActions::Definition* definition = action.id != GI_ACTION_NONE ? GIActions::Get(action.id) : nullptr;
+    if (definition != nullptr && definition->exclusionGroup != GI_EXCLUSION_NONE) {
+        for (const auto& active : activeActions) {
+            if (active.id == action.id) {
+                continue; // Same action: already settled by its stacking rule above.
+            }
+            const GIActions::Definition* other = GIActions::Get(active.id);
+            if (other != nullptr && other->exclusionGroup == definition->exclusionGroup) {
+                return GI_AVAILABILITY_NOT_YET;
+            }
+        }
+    }
+
+    return GI_AVAILABILITY_READY;
+}
+
+void GameInteractor::Dispatch(GIAction action) {
+    if (action.duration > 0 && action.id != GI_ACTION_NONE) {
+        const GIActions::Definition* definition = GIActions::Get(action.id);
+        if (definition != nullptr && definition->stacking == GI_STACK_REFRESH) {
+            for (auto& active : activeActions) {
+                if (active.id == action.id) {
+                    active.elapsed = 0;
+                    active.duration = action.duration;
+                    active.params = std::move(action.params);
+                    Complete(action, GI_STATUS_APPLIED);
+                    return;
                 }
-            },
-            e->drawItem);
-        enItem00->actor.destroy = [](Actor* actor, PlayState* play) {
-            if (!(CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION)) {
-                // Event was not handled, requeue it
-                auto lostEvent = GameInteractor::Instance->currentEvent;
-                GameInteractor::Instance->currentEvent = GIEventNone{};
-                GameInteractor::Instance->events.push_back(lostEvent);
             }
-        };
-    } else if (auto e = std::get_if<GIEventTransition>(&nextEvent)) {
-        gPlayState->nextEntrance = e->entrance;
-        gSaveContext.nextCutsceneIndex = e->cutsceneIndex;
-        gPlayState->transitionTrigger = e->transitionTrigger;
-        gPlayState->transitionType = e->transitionType;
-        GameInteractor::Instance->currentEvent = GIEventNone{};
-    } else if (auto e = std::get_if<GIEventSpawnActor>(&nextEvent)) {
-        // if true, the coordinates are made relative to the player's position and rotation, 0 rotation is facing the
-        // same direction as the player, x+ is to the players right, y+ is up, z+ is in front of the player
-        if (e->relativeCoords) {
-            f32 x = player->actor.world.pos.x;
-            f32 y = player->actor.world.pos.y;
-            f32 z = player->actor.world.pos.z;
-            f32 s = sin(player->actor.world.rot.y);
-            f32 c = cos(player->actor.world.rot.y);
-            f32 x2 = e->posX * c - e->posZ * s;
-            f32 z2 = e->posX * s + e->posZ * c;
-            Actor_Spawn(&gPlayState->actorCtx, gPlayState, e->actorId, x + x2, y + e->posY, z + z2, 0,
-                        e->rotY + player->actor.world.rot.y, 0, e->params);
-        } else {
-            Actor_Spawn(&gPlayState->actorCtx, gPlayState, e->actorId, e->posX, e->posY, e->posZ, e->rotX, e->rotY,
-                        e->rotZ, e->params);
-        }
-        GameInteractor::Instance->currentEvent = GIEventNone{};
-    } else if (auto e = std::get_if<GIEventTrap>(&nextEvent)) {
-        if (player->stateFlags1 & PLAYER_STATE1_800000) {
-            // Player is riding a horse, requeue the event
-            auto lostEvent = GameInteractor::Instance->currentEvent;
-            GameInteractor::Instance->currentEvent = GIEventNone{};
-            GameInteractor::Instance->events.push_back(lostEvent);
-        } else {
-            if (e->action) {
-                e->action();
-            }
-            GameInteractor::Instance->currentEvent = GIEventNone{};
         }
     }
 
-    GameInteractor::Instance->events.erase(GameInteractor::Instance->events.begin());
+    action.elapsed = 0;
+
+    if (action.onStart) {
+        action.onStart(action);
+    }
+
+    if (action.duration == 0 && !action.blocking) {
+        Complete(action, GI_STATUS_APPLIED);
+        return;
+    }
+
+    if (!action.blocking) {
+        Complete(action, GI_STATUS_APPLIED);
+    }
+
+    activeActions.push_back(std::move(action));
+}
+
+void GameInteractor::ProcessQueue(bool canApply) {
+    for (size_t i = 0; i < actions.size();) {
+        switch (canApply ? GetAvailability(actions[i]) : GI_AVAILABILITY_NOT_YET) {
+            case GI_AVAILABILITY_READY: {
+                GIAction action = std::move(actions[i]);
+                actions.erase(actions.begin() + i);
+                Dispatch(std::move(action));
+                return;
+            }
+            case GI_AVAILABILITY_NOT_YET: {
+                actions[i].framesWaiting++;
+                if (actions[i].expiresAfter > 0 && actions[i].framesWaiting >= actions[i].expiresAfter) {
+                    GIAction expired = std::move(actions[i]);
+                    actions.erase(actions.begin() + i);
+                    Complete(expired, GI_STATUS_EXPIRED);
+                } else {
+                    i++;
+                }
+                break;
+            }
+            case GI_AVAILABILITY_NEVER: {
+                GIAction impossible = std::move(actions[i]);
+                actions.erase(actions.begin() + i);
+                Complete(impossible, GI_STATUS_IMPOSSIBLE);
+                break;
+            }
+        }
+    }
+}
+
+void GameInteractor::TickActiveActions() {
+    for (size_t i = 0; i < activeActions.size();) {
+        if (activeActions[i].onTick) {
+            activeActions[i].onTick(activeActions[i]);
+        }
+
+        if (activeActions[i].duration == 0) {
+            i++;
+            continue;
+        }
+
+        activeActions[i].elapsed++;
+        if (activeActions[i].elapsed >= activeActions[i].duration) {
+            GIAction finished = std::move(activeActions[i]);
+            activeActions.erase(activeActions.begin() + i);
+            if (finished.onEnd) {
+                finished.onEnd(finished);
+            }
+            Complete(finished, GI_STATUS_FINISHED);
+        } else {
+            i++;
+        }
+    }
+}
+
+const GIAction* GameInteractor::BlockingAction() const {
+    for (const auto& active : activeActions) {
+        if (active.blocking) {
+            return &active;
+        }
+    }
+    return nullptr;
+}
+
+void GameInteractor::FinishBlocking(GIActionStatus status) {
+    for (size_t i = 0; i < activeActions.size(); i++) {
+        if (!activeActions[i].blocking) {
+            continue;
+        }
+
+        GIAction action = std::move(activeActions[i]);
+        activeActions.erase(activeActions.begin() + i);
+        if (action.onEnd) {
+            action.onEnd(action);
+        }
+        Complete(action, status);
+        return;
+    }
+}
+
+void GameInteractor::RequeueBlocking() {
+    for (size_t i = 0; i < activeActions.size(); i++) {
+        if (!activeActions[i].blocking) {
+            continue;
+        }
+
+        GIAction action = std::move(activeActions[i]);
+        activeActions.erase(activeActions.begin() + i);
+        action.elapsed = 0;
+        action.framesWaiting = 0;
+        actions.push_back(std::move(action));
+        return;
+    }
+}
+
+static int DrainIf(std::vector<GIAction>& list, const std::function<bool(const GIAction&)>& match, bool runOnEnd) {
+    int drained = 0;
+    for (size_t i = 0; i < list.size();) {
+        if (!match(list[i])) {
+            i++;
+            continue;
+        }
+
+        GIAction action = std::move(list[i]);
+        list.erase(list.begin() + i);
+        if (runOnEnd && action.onEnd) {
+            action.onEnd(action);
+        }
+        Complete(action, GI_STATUS_CANCELLED);
+        drained++;
+    }
+    return drained;
+}
+
+void GameInteractor::ClearSaveScopedActions() {
+    auto isSaveScoped = [](const GIAction& action) { return action.lifetime == GI_LIFETIME_SAVE; };
+
+    DrainIf(actions, isSaveScoped, false);
+    DrainIf(activeActions, isSaveScoped, true);
+}
+
+int GameInteractor::CancelAction(GIActionId id) {
+    auto matches = [id](const GIAction& action) { return action.id == id; };
+
+    return DrainIf(activeActions, matches, true) + DrainIf(actions, matches, false);
+}
+
+void GameInteractor::CancelAllActions() {
+    auto everything = [](const GIAction&) { return true; };
+
+    DrainIf(activeActions, everything, true);
+    DrainIf(actions, everything, false);
+}
+
+void ProcessActions(Actor* actor) {
+    GameInteractor::Instance->TickActiveActions();
+
+    bool canApply = GameInteractor::Instance->CanProcessActions() == GI_AVAILABILITY_READY &&
+                    GameInteractor::Instance->BlockingAction() == nullptr;
+
+    GameInteractor::Instance->ProcessQueue(canApply);
 }
 
 // On MSVC this is defined inline in the header instead; see the declaration for why.
@@ -610,5 +749,8 @@ void GameInteractor::RegisterOwnHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>(
         []() { GameInteractor::Instance->RemoveAllQueuedHooks(); });
 
-    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, ProcessEvents);
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, ProcessActions);
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(
+        [](s16 fileNum) { GameInteractor::Instance->ClearSaveScopedActions(); });
 }

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -62,21 +62,17 @@ typedef enum {
     GI_DPAD_EQUIP,
 } GIDpadType;
 
-typedef enum {
-    GI_EVENT_NONE,
-    GI_EVENT_GIVE_ITEM,
-    GI_EVENT_SPAWN_ACTOR,
-    GI_EVENT_TRANSITION,
-} GIEventType;
-
 #ifdef __cplusplus
 
 #include <vector>
 #include <functional>
 #include <map>
+#include <optional>
 #include <unordered_map>
 #include <cstdint>
 #include <algorithm>
+
+#include "GameInteractorAction.h"
 
 #include <version>
 #ifdef __cpp_lib_source_location
@@ -129,56 +125,33 @@ struct HookInfo {
 #define GET_CURRENT_REGISTERING_INFO(type) (HookRegisteringInfo{})
 #endif
 
-struct GIEventNone {};
-
-struct GIEventGiveItem {
-    // Whether or not to show the get item cutscene. If true and the player is in the air, the
-    // player will instead be frozen for a few seconds. If this is true you _must_ call
-    // CustomMessage::SetActiveCustomMessage in the giveItem function otherwise you'll just see a blank message.
-    bool showGetItemCutscene;
-    // Arbitrary s16 that can be accessed from within the give/draw functions with CUSTOM_ITEM_PARAM
-    s16 param;
-    // These are run in the context of an item00 actor. This isn't super important but can be useful in some cases
-    ActorFunc giveItem;
-    ActorFunc drawItem;
-};
-
-struct GIEventSpawnActor {
-    s16 actorId;
-    f32 posX;
-    f32 posY;
-    f32 posZ;
-    s16 rotX;
-    s16 rotY;
-    s16 rotZ;
-    s32 params;
-    // if true, the coordinates are made relative to the player's position and rotation, 0 rotation is facing the same
-    // direction as the player, x+ is to the players right, y+ is up, z+ is in front of the player
-    bool relativeCoords;
-};
-
-struct GIEventTransition {
-    u16 entrance;
-    u16 cutsceneIndex;
-    s8 transitionTrigger;
-    u8 transitionType;
-};
-
-struct GIEventTrap {
-    std::function<void()> action;
-};
-
-typedef std::variant<GIEventNone, GIEventGiveItem, GIEventSpawnActor, GIEventTransition, GIEventTrap> GIEvent;
-
 class GameInteractor {
   public:
     static GameInteractor* Instance;
 
     void RegisterOwnHooks();
 
-    // Game State
-    std::vector<GIEvent> events = {};
-    GIEvent currentEvent = GIEventNone();
+    void Queue(GIAction action);
+    GIActionAvailability CanProcessActions();
+    void FinishBlocking(GIActionStatus status);
+    void RequeueBlocking();
+    void ClearSaveScopedActions();
+    int CancelAction(GIActionId id);
+    void CancelAllActions();
+    const GIAction* FindActive(GIActionId id);
+    bool IsActionActive(GIActionId id) {
+        return FindActive(id) != nullptr;
+    }
+
+    // Read-only views, for the Action Debugger. Nothing else should need them.
+    const std::vector<GIAction>& PendingActions() const {
+        return actions;
+    }
+    const std::vector<GIAction>& ActiveActions() const {
+        return activeActions;
+    }
+    // The active action holding the queue, if any.
+    const GIAction* BlockingAction() const;
 
     // Game Hooks
     HOOK_ID nextHookId = 1;
@@ -485,6 +458,19 @@ class GameInteractor {
 #include "GameInteractor_HookTable.h"
 
 #undef DEFINE_HOOK
+
+  private:
+    friend void ProcessActions(Actor* actor);
+
+    void ProcessQueue(bool canApply);
+    void TickActiveActions();
+    GIActionAvailability GetAvailability(const GIAction& action);
+    void Dispatch(GIAction action);
+
+    // Waiting to be applied.
+    std::vector<GIAction> actions = {};
+    // Everything currently in progress.
+    std::vector<GIAction> activeActions = {};
 };
 
 extern "C" {

--- a/mm/2s2h/GameInteractor/GameInteractorAction.h
+++ b/mm/2s2h/GameInteractor/GameInteractorAction.h
@@ -1,0 +1,142 @@
+#ifndef GAME_INTERACTOR_ACTION_H
+#define GAME_INTERACTOR_ACTION_H
+
+#ifdef __cplusplus
+
+#include <cstdint>
+#include <functional>
+
+#include "GameInteractorParams.h"
+
+typedef enum {
+    GI_AVAILABILITY_READY,   // Apply it now.
+    GI_AVAILABILITY_NOT_YET, // Temporarily blocked. Leave it queued and ask again next frame.
+    GI_AVAILABILITY_NEVER,   // It will never apply. Drop it and tell the emitter.
+} GIActionAvailability;
+
+// Reported back to whoever queued the action, via onComplete.
+typedef enum {
+    GI_STATUS_APPLIED,    // An instant action ran, a timed one started, or a blocking one delivered.
+    GI_STATUS_FINISHED,   // A timed action's duration elapsed.
+    GI_STATUS_CANCELLED,  // Ended or dropped before it could finish, by a cancel or a save load.
+    GI_STATUS_EXPIRED,    // The game was never ready within expiresAfter. Nothing happened; retry.
+    GI_STATUS_IMPOSSIBLE, // A gate said it can never apply. Nothing happened; don't retry.
+} GIActionStatus;
+
+typedef enum {
+    GI_LIFETIME_SAVE,    // Dropped when a save is loaded.
+    GI_LIFETIME_SESSION, // Survives everything. Only its duration, a cancel, or the emitter ends it.
+} GIActionLifetime;
+
+typedef enum {
+    // Anonymous: carries its own closures rather than coming from a registered definition.
+    GI_ACTION_NONE,
+
+    // Core mechanisms
+    GI_ACTION_GIVE_ITEM,
+    GI_ACTION_TRANSITION,
+    GI_ACTION_SPAWN_ACTOR,
+    GI_ACTION_SHOW_MESSAGE,
+    GI_ACTION_SHOW_TITLE_CARD,
+
+    // Effects
+    GI_ACTION_FREEZE,
+    GI_ACTION_BLAST,
+    GI_ACTION_SHOCK,
+    GI_ACTION_JINX,
+    GI_ACTION_EMPTY_WALLET,
+    GI_ACTION_SPAWN_LIKE_LIKE,
+    GI_ACTION_SKIP_TIME,
+    GI_ACTION_BURN,
+    GI_ACTION_KNOCKBACK,
+    GI_ACTION_SCALE_LINK,
+    GI_ACTION_PAPER_LINK,
+    GI_ACTION_SQUISH_LINK,
+    GI_ACTION_MIRROR_LINK,
+    GI_ACTION_DRUNK_LINK,
+    GI_ACTION_BUTTON_ROULETTE,
+    GI_ACTION_MOTION_BLUR,
+    GI_ACTION_SHRINK_SCREEN,
+    GI_ACTION_MIRROR_CAMERA,
+    GI_ACTION_CAMERA_TILT,
+    GI_ACTION_UPSIDE_DOWN_CAMERA,
+    GI_ACTION_RANDOM_SKYBOX,
+    GI_ACTION_FOG,
+    GI_ACTION_BOUNCING_B_BUTTON,
+    GI_ACTION_DAMAGE_MULTIPLIER,
+    GI_ACTION_INVINCIBILITY,
+    GI_ACTION_SPEED,
+    GI_ACTION_SLIPPERY_FLOOR,
+    GI_ACTION_RANDOM_WIND,
+    GI_ACTION_HEALTH,
+    GI_ACTION_RUPEES,
+    GI_ACTION_KILL_LINK,
+    GI_ACTION_RANDOMIZE_COSMETICS,
+    GI_ACTION_REVERSE_CONTROLS,
+    GI_ACTION_CLEAR_BUTTONS,
+} GIActionId;
+
+// Metadata for remotes and UI only.
+typedef enum {
+    GI_VALENCE_NEUTRAL,
+    GI_VALENCE_POSITIVE,
+    GI_VALENCE_NEGATIVE,
+} GIValence;
+
+// What to do when a timed action is requested while an instance of it is already running.
+typedef enum {
+    GI_STACK_QUEUE,   // Wait for the running one to end (NOT_YET).
+    GI_STACK_REFRESH, // Restart the running one with the new request's duration and params.
+} GIStacking;
+
+// Actions in the same group write the same game state, so only one of them runs at a time.
+typedef enum {
+    GI_EXCLUSION_NONE,
+    GI_EXCLUSION_PLAYER_SCALE,
+    GI_EXCLUSION_CAMERA_ROLL,
+} GIExclusionGroup;
+
+struct GIAction;
+
+using GIActionCallback = std::function<void(GIActionStatus)>;
+using GIActionGate = std::function<GIActionAvailability(const GIAction&)>;
+using GIActionFunc = std::function<void(GIAction&)>;
+
+struct GIAction {
+    // Identity for stacking and cancellation; the callbacks below are what actually runs.
+    GIActionId id = GI_ACTION_NONE;
+    GIParams params = {};
+    // Frames the action runs for. 0 means onStart is the whole thing.
+    uint32_t duration = 0;
+    // Holds the queue until the action calls GameInteractor::FinishBlocking(). An onStart that
+    // fails to get going should clear this so it doesn't hold the queue forever.
+    bool blocking = false;
+    GIActionLifetime lifetime = GI_LIFETIME_SAVE;
+    // Frames to wait for READY before giving up and reporting EXPIRED. 0 waits forever.
+    uint32_t expiresAfter = 0;
+
+    // Reports APPLIED when the action lands, FINISHED/CANCELLED later if it was timed, or exactly
+    // one of CANCELLED/EXPIRED/IMPOSSIBLE if it never ran.
+    GIActionCallback onComplete = nullptr;
+    // Checked every frame while queued, on top of GameInteractor::CanProcessActions().
+    GIActionGate canApply = nullptr;
+
+    GIActionFunc onStart = nullptr;
+    GIActionFunc onTick = nullptr; // Timed only. Every frame, including the frame it started.
+    GIActionFunc onEnd = nullptr;  // Timed only. When the duration elapses or it's cancelled.
+
+    // Runtime state, written by the processor.
+    uint32_t elapsed = 0;       // Frames since onStart ran.
+    uint32_t framesWaiting = 0; // Frames spent queued while not READY.
+
+    // Rvalue-only so chaining onto a factory result moves rather than copies:
+    //   Queue(GIActions::GiveItem({ ... }).OnComplete([](GIActionStatus s) { ... }));
+    GIAction&& OnComplete(GIActionCallback callback) && {
+        onComplete = std::move(callback);
+        return std::move(*this);
+    }
+};
+
+#endif // __cplusplus
+
+#endif // GAME_INTERACTOR_ACTION_H

--- a/mm/2s2h/GameInteractor/GameInteractorParams.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractorParams.cpp
@@ -1,0 +1,84 @@
+#include "GameInteractorParams.h"
+
+const char* GIParamTypeName(GIParamType type) {
+    switch (type) {
+        case GI_PARAM_BOOL:
+            return "bool";
+        case GI_PARAM_INT:
+            return "int";
+        case GI_PARAM_FLOAT:
+            return "float";
+        case GI_PARAM_STRING:
+            return "string";
+    }
+    return "unknown";
+}
+
+bool GIParams::Bool(const std::string& key) const {
+    auto it = values.find(key);
+    return it == values.end() ? false : std::get<bool>(it->second);
+}
+
+int32_t GIParams::Int(const std::string& key) const {
+    auto it = values.find(key);
+    return it == values.end() ? 0 : std::get<int32_t>(it->second);
+}
+
+float GIParams::Float(const std::string& key) const {
+    auto it = values.find(key);
+    return it == values.end() ? 0.0f : std::get<float>(it->second);
+}
+
+const std::string& GIParams::String(const std::string& key) const {
+    static const std::string empty;
+    auto it = values.find(key);
+    return it == values.end() ? empty : std::get<std::string>(it->second);
+}
+
+static GIParamValue ZeroValueFor(GIParamType type) {
+    switch (type) {
+        case GI_PARAM_BOOL:
+            return false;
+        case GI_PARAM_INT:
+            return static_cast<int32_t>(0);
+        case GI_PARAM_FLOAT:
+            return 0.0f;
+        case GI_PARAM_STRING:
+            break;
+    }
+    return std::string();
+}
+
+std::optional<std::string> GIParamsValidate(const std::vector<GIParamSpec>& schema, GIParams& params) {
+    for (const auto& spec : schema) {
+        const GIParamValue* value = params.Find(spec.name);
+
+        if (value == nullptr) {
+            if (spec.required) {
+                return std::string("missing required param '") + spec.name + "'";
+            }
+            params.Set(spec.name, spec.defaultValue.value_or(ZeroValueFor(spec.type)));
+            value = params.Find(spec.name);
+        }
+
+        if (GIParamTypeOf(*value) != spec.type) {
+            // A remote sending {"scale": 3} means 3.0f, not a type error.
+            if (spec.type == GI_PARAM_FLOAT && GIParamTypeOf(*value) == GI_PARAM_INT) {
+                params.Set(spec.name, static_cast<float>(std::get<int32_t>(*value)));
+            } else {
+                return std::string("param '") + spec.name + "' expects " + GIParamTypeName(spec.type) + ", got " +
+                       GIParamTypeName(GIParamTypeOf(*value));
+            }
+        }
+
+        if (spec.min.has_value() || spec.max.has_value()) {
+            float number =
+                spec.type == GI_PARAM_FLOAT ? params.Float(spec.name) : static_cast<float>(params.Int(spec.name));
+            if ((spec.min.has_value() && number < *spec.min) || (spec.max.has_value() && number > *spec.max)) {
+                return std::string("param '") + spec.name + "' is out of range";
+            }
+        }
+    }
+
+    return std::nullopt;
+}

--- a/mm/2s2h/GameInteractor/GameInteractorParams.h
+++ b/mm/2s2h/GameInteractor/GameInteractorParams.h
@@ -1,0 +1,73 @@
+#ifndef GAME_INTERACTOR_PARAMS_H
+#define GAME_INTERACTOR_PARAMS_H
+
+#ifdef __cplusplus
+
+#include <cstdint>
+#include <initializer_list>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+// Passing a double (`1.5`) is a compile error because it narrows -- write `1.5f`.
+using GIParamValue = std::variant<bool, int32_t, float, std::string>;
+
+// Must stay in the same order as GIParamValue's alternatives; GIParamTypeOf() relies on it.
+typedef enum {
+    GI_PARAM_BOOL,
+    GI_PARAM_INT,
+    GI_PARAM_FLOAT,
+    GI_PARAM_STRING,
+} GIParamType;
+
+const char* GIParamTypeName(GIParamType type);
+
+inline GIParamType GIParamTypeOf(const GIParamValue& value) {
+    return static_cast<GIParamType>(value.index());
+}
+
+class GIParams {
+  public:
+    GIParams() = default;
+    GIParams(std::initializer_list<std::pair<const std::string, GIParamValue>> init) : values(init) {
+    }
+
+    void Set(std::string key, GIParamValue value) {
+        values.insert_or_assign(std::move(key), std::move(value));
+    }
+    const GIParamValue* Find(const std::string& key) const {
+        auto it = values.find(key);
+        return it == values.end() ? nullptr : &it->second;
+    }
+
+    // Guaranteed to succeed for every key the schema declares, once the params have been validated.
+    bool Bool(const std::string& key) const;
+    int32_t Int(const std::string& key) const;
+    float Float(const std::string& key) const;
+    const std::string& String(const std::string& key) const;
+
+  private:
+    std::unordered_map<std::string, GIParamValue> values;
+};
+
+struct GIParamSpec {
+    const char* name;
+    GIParamType type;
+    bool required = false;
+    // Used when the param is absent and not required. Defaults to the zero value for `type`.
+    std::optional<GIParamValue> defaultValue = std::nullopt;
+    // Inclusive bounds for INT/FLOAT params.
+    std::optional<float> min = std::nullopt;
+    std::optional<float> max = std::nullopt;
+};
+
+// Fills in defaults, widens ints where the schema wants a float, and range-checks. Returns a
+// description of the first problem, or nullopt if `params` is now safe to hand to callbacks.
+std::optional<std::string> GIParamsValidate(const std::vector<GIParamSpec>& schema, GIParams& params);
+
+#endif // __cplusplus
+
+#endif // GAME_INTERACTOR_PARAMS_H

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1466,6 +1466,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*f32` (height)
+    VB_MODIFY_CAMERA_FOCAL_HEIGHT,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - None
     VB_MINIMAP_TOGGLE,
 
@@ -1542,6 +1550,15 @@ typedef enum {
     // #### `args`
     // - `*EnKakasi`
     VB_NEED_SCARECROW_SONG,
+
+    // #### `result`
+    // ```c
+    // (player->stateFlags3 & PLAYER_STATE3_1) || !(player->actor.scale.y >= 0.0f) ||
+    // (player->stateFlags1 & PLAYER_STATE1_DEAD) || play->soaringCsOrSoTCsPlaying
+    // ```
+    // #### `args`
+    // - None
+    VB_NOT_ADJUST_PLAYER_LEGS,
 
     // #### `result`
     // ```c

--- a/mm/2s2h/Network/Network.cpp
+++ b/mm/2s2h/Network/Network.cpp
@@ -1,0 +1,184 @@
+#include "Network.h"
+#include <spdlog/spdlog.h>
+#include <libultraship/libultraship.h>
+#include <chrono>
+
+// MARK: - Public
+
+bool Network::Enable(const char* host, uint16_t port) {
+    if (isEnabled) {
+        return true;
+    }
+
+    if (SDLNet_ResolveHost(&networkAddress, host, port) == -1) {
+        SPDLOG_ERROR("[Network] SDLNet_ResolveHost: {}", SDLNet_GetError());
+        return false;
+    }
+
+    isEnabled = true;
+
+    // First check if there is a thread running, if so, join it
+    if (receiveThread.joinable()) {
+        receiveThread.join();
+    }
+
+    receiveThread = std::thread(&Network::ReceiveFromServer, this);
+    return true;
+}
+
+void Network::Disable() {
+    if (!isEnabled) {
+        return;
+    }
+
+    isEnabled = false;
+    if (receiveThread.joinable()) {
+        receiveThread.join();
+    }
+    isConnected = false;
+}
+
+void Network::OnConnected() {
+}
+
+void Network::OnDisconnected() {
+}
+
+void Network::SwapIncomingPacketQueue(std::queue<nlohmann::json>& emptyQueue) {
+    std::lock_guard<std::mutex> lock(incomingPacketQueueMutex);
+    std::swap(incomingPacketQueue, emptyQueue);
+}
+
+void Network::QueueOutgoingPacket(nlohmann::json packet) {
+    if (!isConnected) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(outgoingPacketQueueMutex);
+    outgoingPacketQueue.push(std::move(packet));
+}
+
+// MARK: - Private
+
+void Network::ReceiveFromServer() {
+    while (isEnabled) {
+        while (!isConnected && isEnabled) {
+            SPDLOG_TRACE("[Network] Attempting to make connection to server...");
+            networkSocket = SDLNet_TCP_Open(&networkAddress);
+
+            if (networkSocket) {
+                isConnected = true;
+                receivedData.clear();
+                SPDLOG_INFO("[Network] Connection to server established!");
+
+                OnConnected();
+                break;
+            }
+
+            for (int i = 0; i < 1000 / 100 && isEnabled; i++) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+        }
+
+        SDLNet_SocketSet socketSet = SDLNet_AllocSocketSet(1);
+        if (networkSocket) {
+            SDLNet_TCP_AddSocket(socketSet, networkSocket);
+        }
+
+        // Listen to socket messages
+        while (isConnected && networkSocket && isEnabled) {
+            // we check first if socket has data, to not block in the TCP_Recv
+            int socketsReady = SDLNet_CheckSockets(socketSet, 10); // 10ms timeout
+
+            if (socketsReady == -1) {
+                SPDLOG_ERROR("[Network] SDLNet_CheckSockets: {}", SDLNet_GetError());
+                break;
+            }
+
+            if (socketsReady > 0) {
+                char remoteDataReceived[512];
+                memset(remoteDataReceived, 0, sizeof(remoteDataReceived));
+                int len = SDLNet_TCP_Recv(networkSocket, &remoteDataReceived, sizeof(remoteDataReceived));
+                if (!len || !networkSocket || len == -1) {
+                    SPDLOG_ERROR("[Network] SDLNet_TCP_Recv: {}", SDLNet_GetError());
+                    break;
+                }
+
+                receivedData.append(remoteDataReceived, len);
+
+                // Process all complete packets
+                size_t delimiterPos = receivedData.find('\0');
+                while (delimiterPos != std::string::npos) {
+                    // Extract the complete packet until the delimiter
+                    std::string packet = receivedData.substr(0, delimiterPos);
+                    // Remove the packet (including the delimiter) from the received data
+                    receivedData.erase(0, delimiterPos + 1);
+                    HandleCompletePacket(packet);
+                    // Find the next delimiter
+                    delimiterPos = receivedData.find('\0');
+                }
+            }
+
+            // Always send outgoing packets, not just when receiving data
+            ProcessOutgoingPackets();
+        }
+
+        if (socketSet) {
+            SDLNet_FreeSocketSet(socketSet);
+        }
+
+        if (isConnected && networkSocket) {
+            SDLNet_TCP_Close(networkSocket);
+            networkSocket = nullptr;
+            isConnected = false;
+            receivedData.clear();
+            {
+                std::lock_guard<std::mutex> lock(outgoingPacketQueueMutex);
+                outgoingPacketQueue = {};
+            }
+            OnDisconnected();
+            SPDLOG_INFO("[Network] Ending receiving thread...");
+        }
+    }
+}
+
+void Network::HandleCompletePacket(std::string payload) {
+    SPDLOG_TRACE("[Network] Received json:\n{}", payload);
+    try {
+        nlohmann::json jsonPayload = nlohmann::json::parse(payload);
+        std::lock_guard<std::mutex> lock(incomingPacketQueueMutex);
+        incomingPacketQueue.push(jsonPayload);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[Network] Failed to parse json: \n{}\n{}\n", payload, e.what());
+        return;
+    }
+}
+
+void Network::ProcessOutgoingPackets() {
+    if (!isConnected || !networkSocket) {
+        return;
+    }
+
+    // Copy all queued packets while holding the lock, then send them after releasing
+    std::queue<nlohmann::json> packetsToSend;
+    {
+        std::lock_guard<std::mutex> lock(outgoingPacketQueueMutex);
+        packetsToSend.swap(outgoingPacketQueue);
+    }
+
+    while (!packetsToSend.empty()) {
+        nlohmann::json payload = std::move(packetsToSend.front());
+        packetsToSend.pop();
+
+        std::string rawPayload = payload.dump();
+        if (!payload.contains("quiet")) {
+            SPDLOG_TRACE("[Network] Sending json:\n{}", rawPayload);
+        }
+
+        int sent = SDLNet_TCP_Send(networkSocket, rawPayload.c_str(), rawPayload.length() + 1);
+        if (sent < (int)(rawPayload.length() + 1)) {
+            SPDLOG_ERROR("[Network] SDLNet_TCP_Send: {}", SDLNet_GetError());
+            return;
+        }
+    }
+}

--- a/mm/2s2h/Network/Network.h
+++ b/mm/2s2h/Network/Network.h
@@ -1,0 +1,42 @@
+#ifndef NETWORK_H
+#define NETWORK_H
+#ifdef __cplusplus
+
+#include <atomic>
+#include <thread>
+#include <SDL2/SDL_net.h>
+#include <nlohmann/json.hpp>
+
+class Network {
+  private:
+    IPaddress networkAddress;
+    TCPsocket networkSocket;
+    std::thread receiveThread;
+    std::string receivedData;
+
+    void ReceiveFromServer();
+    void HandleCompletePacket(std::string payload);
+    void ProcessOutgoingPackets();
+
+    std::mutex incomingPacketQueueMutex;
+    std::queue<nlohmann::json> incomingPacketQueue;
+    std::mutex outgoingPacketQueueMutex;
+    std::queue<nlohmann::json> outgoingPacketQueue;
+
+  public:
+    std::atomic<bool> isEnabled{ false };
+    std::atomic<bool> isConnected{ false };
+
+    bool Enable(const char* host, uint16_t port);
+    void Disable();
+
+    virtual void OnConnected();
+    virtual void OnDisconnected();
+
+    // To be called from the Game thread
+    void SwapIncomingPacketQueue(std::queue<nlohmann::json>& emptyQueue);
+    void QueueOutgoingPacket(nlohmann::json packet);
+};
+
+#endif // __cplusplus
+#endif // NETWORK_H

--- a/mm/2s2h/Network/NetworkMenu.cpp
+++ b/mm/2s2h/Network/NetworkMenu.cpp
@@ -1,0 +1,93 @@
+#include "2s2h/BenGui/UIWidgets.hpp"
+#include "ShipUtils.h"
+#include "2s2h/BenGui/BenMenu.h"
+#include "2s2h/BenGui/Notification.h"
+#include "2s2h/Network/Sail/Sail.h"
+
+namespace BenGui {
+extern std::shared_ptr<BenMenu> mBenMenu;
+} // namespace BenGui
+using namespace UIWidgets;
+
+void RegisterNetworkMenu() {
+    // Add Network Menu
+    BenGui::mBenMenu->AddMenuEntry("Network", "gSettings.Menu.NetworkSidebarSection");
+    WidgetPath path;
+
+    // Sail
+    path = { "Network", "Sail", SECTION_COLUMN_1 };
+    BenGui::mBenMenu->AddSidebarEntry("Network", path.sidebarName, 3);
+    BenGui::mBenMenu->AddWidget(path, "Host & Port", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        ImGui::BeginDisabled(Sail::Instance->isEnabled);
+        ImGui::Text("%s", info.name.c_str());
+        CVarInputString("##HostSail", "gNetwork.Sail.Host",
+                        InputOptions()
+                            .PlaceholderText("127.0.0.1")
+                            .DefaultValue("127.0.0.1")
+                            .Size(ImVec2(ImGui::GetContentRegionAvail().x - ImGui::GetFontSize() * 7, 0))
+                            .LabelPosition(LabelPosition::None));
+        ImGui::SameLine();
+        ImGui::Text(":");
+        ImGui::SameLine();
+        CVarInputInt("##PortSail", "gNetwork.Sail.Port",
+                     InputOptions()
+                         .PlaceholderText("43384")
+                         .DefaultValue("43384")
+                         .Size(ImVec2(ImGui::GetFontSize() * 5, 0))
+                         .LabelPosition(LabelPosition::None));
+        ImGui::EndDisabled();
+    });
+    BenGui::mBenMenu->AddWidget(path, "Enable##Sail", WIDGET_BUTTON)
+        .PreFunc([](WidgetInfo& info) {
+            std::string host = CVarGetString("gNetwork.Sail.Host", "127.0.0.1");
+            uint16_t port = CVarGetInteger("gNetwork.Sail.Port", 43384);
+            info.options->disabled = !(!IsStringEmpty(host) && port > 1024 && port < 65535);
+            if (Sail::Instance->isEnabled) {
+                info.name = "Disable##Sail";
+            } else {
+                info.name = "Enable##Sail";
+            }
+        })
+        .Callback([](WidgetInfo& info) {
+            if (Sail::Instance->isEnabled) {
+                CVarClear("gNetwork.Sail.Enabled");
+                Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                Sail::Instance->Disable();
+            } else if (Sail::Instance->Enable()) {
+                CVarSetInteger("gNetwork.Sail.Enabled", 1);
+                Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            } else {
+                Notification::Emit({ .message = "Couldn't resolve the Sail host" });
+            }
+        });
+    BenGui::mBenMenu->AddWidget(path, "Connecting...", WIDGET_TEXT).PreFunc([](WidgetInfo& info) {
+        info.isHidden = !Sail::Instance->isEnabled;
+        if (Sail::Instance->isConnected) {
+            info.name = "Connected##Sail";
+        } else {
+            info.name = "Connecting...##Sail";
+        }
+    });
+    path.column = SECTION_COLUMN_2;
+    BenGui::mBenMenu->AddWidget(path,
+                                "Sail is a networking protocol designed to facilitate remote "
+                                "control of the 2Ship2Harkinian client. It is intended to "
+                                "be utilized alongside a Sail server, for which we provide a "
+                                "few straightforward implementations on our GitHub. The current "
+                                "implementations available allow integration with Twitch chat "
+                                "and SAMMI Bot, feel free to contribute your own!\n"
+                                "\n"
+                                "Click this button to copy the link to the Sail Github "
+                                "page to your clipboard.",
+                                WIDGET_TEXT);
+    BenGui::mBenMenu->AddWidget(path, ICON_FA_CLIPBOARD "##Sail", WIDGET_BUTTON)
+        .Callback([](WidgetInfo& info) {
+            ImGui::SetClipboardText("https://github.com/HarbourMasters/sail");
+            Notification::Emit({
+                .message = "Copied to clipboard",
+            });
+        })
+        .Options(ButtonOptions().Tooltip("https://github.com/HarbourMasters/sail"));
+}
+
+static RegisterMenuInitFunc initFunc(RegisterNetworkMenu);

--- a/mm/2s2h/Network/Sail/Sail.cpp
+++ b/mm/2s2h/Network/Sail/Sail.cpp
@@ -1,0 +1,522 @@
+#include "Sail.h"
+#include <libultraship/libultraship.h>
+#include <nlohmann/json.hpp>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+// Sail lets something outside the game make it do things. Every message carries an `id` that comes
+// back on the reply.
+//
+//   -> { "id":1, "type":"command", "command":"reset" }
+//   <- { "id":1, "type":"result", "outcome":"ok" }
+//
+//   -> { "id":2, "type":"action.apply", "name":"scaleLink",
+//        "params":{"scale":0.4}, "duration":600, "expiresAfter":600, "lifetime":"session" }
+//   <- { "id":2, "type":"result", "outcome":"applied" }
+//   <- { "id":2, "type":"action.ended", "outcome":"finished" }   // later, unsolicited
+//
+//   -> { "id":3, "type":"action.remove", "name":"scaleLink" }
+//   <- { "id":3, "type":"result", "outcome":"ok", "cancelled":1 }
+//
+//   -> { "id":4, "type":"action.list" }
+//   <- { "id":4, "type":"result", "outcome":"ok", "protocol":2, "actions":[...] }
+//
+//   -> { "id":5, "type":"action.status" }
+//   <- { "id":5, "type":"result", "outcome":"ok", "ready":true, "pending":0, "active":1 }
+//
+//   -> { "id":6, "type":"hook.list" }
+//   <- { "id":6, "type":"result", "outcome":"ok", "hooks":[{"name":"OnItemGive","idFilter":true}] }
+//
+//   -> { "id":7, "type":"subscribe", "hookName":"OnItemGive", "hookIdFilter":10 }
+//   <- { "id":7, "type":"result", "outcome":"ok" }
+//   <- { "id":*, "type":"hook", "hook":{...} }                   // whenever it fires
+//
+// `outcome` is the only status field, and it's the same word whatever went wrong:
+//
+//   ok         a query or command did what was asked
+//   applied    the action happened
+//   finished   a timed action's duration ran out
+//   cancelled  it was stopped, or dropped when a save loaded
+//   expired    the game never became ready in time -- nothing happened, ask again later
+//   impossible it can never apply as asked -- nothing happened, don't ask again
+//   invalid    the message itself was wrong; `reason` says how
+//
+// An action.apply gets no immediate reply: the answer comes when the action actually lands, so
+// "applied" means it happened rather than "the packet parsed". Only the first word back is a
+// `result`; anything after it is an unsolicited message, so an id is never answered twice.
+//
+// Sail is where JSON stops. Everything below the boundary speaks GIParams, so GameInteractor never
+// learns a wire format and anything else driving it can pick its own protocol.
+
+// Frames an action waits for the game to become ready before giving up, when the sender doesn't
+// say. Something is always waiting on the answer, so the default is finite rather than forever --
+// and twice the longest default duration, so a request queued behind a full-length effect in its
+// exclusion group outlives the wait instead of expiring one frame short of its turn.
+static constexpr uint32_t DEFAULT_EXPIRES_AFTER = 20 * 60; // 60 seconds
+
+// Bumped when the shape of what Sail sends or accepts changes incompatibly. Reported by
+// "action.list" so a server can refuse to talk to a client it doesn't understand.
+static constexpr int SAIL_PROTOCOL_VERSION = 2;
+
+static bool ParamsFromJson(const nlohmann::json& source, GIParams& params, std::string& error) {
+    if (!source.is_object()) {
+        error = "params must be an object";
+        return false;
+    }
+
+    for (auto& [key, value] : source.items()) {
+        if (value.is_boolean()) {
+            params.Set(key, value.get<bool>());
+        } else if (value.is_number_integer()) {
+            params.Set(key, value.get<int32_t>());
+        } else if (value.is_number_float()) {
+            params.Set(key, value.get<float>());
+        } else if (value.is_string()) {
+            params.Set(key, value.get<std::string>());
+        } else {
+            error = "param '" + key + "' is not a bool, number, or string";
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// MARK: - Hooks
+
+static void SendHook(const char* type, nlohmann::json fields) {
+    // Hook messages are unsolicited, so the id just has to exist; a counter keeps them distinct
+    // without pretending anyone asked.
+    static uint32_t nextMessageId = 1;
+    nlohmann::json payload;
+    payload["id"] = nextMessageId++;
+    payload["type"] = "hook";
+    payload["hook"] = std::move(fields);
+    payload["hook"]["type"] = type;
+    Sail::Instance->QueueOutgoingPacket(std::move(payload));
+}
+
+// Argument types must match GameInteractor_HookTable.h exactly. They're implicitly convertible if
+// they don't, so a narrower one compiles and silently truncates on the wire.
+static void OnSceneInitHandler(s8 sceneId, s8 spawnNum) {
+    SendHook("OnSceneInit", { { "sceneId", sceneId } });
+}
+
+static void OnItemGiveHandler(u8 item) {
+    SendHook("OnItemGive", { { "itemId", item } });
+}
+
+static void OnActorInitHandler(Actor* actor) {
+    SendHook("OnActorInit", { { "actorId", actor->id }, { "params", actor->params } });
+}
+
+static void OnFlagSetHandler(FlagType flagType, u32 flag) {
+    SendHook("OnFlagSet", { { "flagType", (int32_t)flagType }, { "flag", flag } });
+}
+
+static void OnFlagUnsetHandler(FlagType flagType, u32 flag) {
+    SendHook("OnFlagUnset", { { "flagType", (int32_t)flagType }, { "flag", flag } });
+}
+
+static void OnSceneFlagSetHandler(s16 sceneId, FlagType flagType, u32 flag) {
+    SendHook("OnSceneFlagSet", { { "sceneId", sceneId }, { "flagType", (int32_t)flagType }, { "flag", flag } });
+}
+
+static void OnSceneFlagUnsetHandler(s16 sceneId, FlagType flagType, u32 flag) {
+    SendHook("OnSceneFlagUnset", { { "sceneId", sceneId }, { "flagType", (int32_t)flagType }, { "flag", flag } });
+}
+
+// One row per hook Sail can forward. The subscribe and unsubscribe thunks close over the hook's
+// type, so it can't be lost between registering and tearing down.
+struct HookBinding {
+    const char* name;
+    // Whether GameInteractor dispatches this hook by id, and so whether `hookIdFilter` means
+    // anything for it. That lives in GameInteractor.cpp's ExecuteHooksForID call sites and has no
+    // representation in the hook table, so it has to be mirrored here by hand.
+    bool idFilter;
+    std::function<HOOK_ID()> subscribe;
+    std::function<HOOK_ID(int32_t)> subscribeForId;
+    std::function<void(HOOK_ID)> unsubscribe;
+    std::function<void(HOOK_ID)> unsubscribeForId;
+};
+
+template <typename H> static HookBinding Bind(const char* name, bool idFilter, typename H::fn handler) {
+    return {
+        name,
+        idFilter,
+        [handler] { return GameInteractor::Instance->RegisterGameHook<H>(handler); },
+        [handler](int32_t id) { return GameInteractor::Instance->RegisterGameHookForID<H>(id, handler); },
+        [](HOOK_ID hookId) { GameInteractor::Instance->UnregisterGameHook<H>(hookId); },
+        [](HOOK_ID hookId) { GameInteractor::Instance->UnregisterGameHookForID<H>(hookId); },
+    };
+}
+
+static const std::vector<HookBinding>& HookBindings() {
+    static const std::vector<HookBinding> bindings = {
+        Bind<GameInteractor::OnSceneInit>("OnSceneInit", true, OnSceneInitHandler),
+        Bind<GameInteractor::OnItemGive>("OnItemGive", true, OnItemGiveHandler),
+        Bind<GameInteractor::OnActorInit>("OnActorInit", true, OnActorInitHandler),
+        Bind<GameInteractor::OnFlagSet>("OnFlagSet", false, OnFlagSetHandler),
+        Bind<GameInteractor::OnFlagUnset>("OnFlagUnset", false, OnFlagUnsetHandler),
+        Bind<GameInteractor::OnSceneFlagSet>("OnSceneFlagSet", false, OnSceneFlagSetHandler),
+        Bind<GameInteractor::OnSceneFlagUnset>("OnSceneFlagUnset", false, OnSceneFlagUnsetHandler),
+    };
+    return bindings;
+}
+
+static const HookBinding* FindHookBinding(const std::string& name) {
+    for (const auto& binding : HookBindings()) {
+        if (name == binding.name) {
+            return &binding;
+        }
+    }
+    return nullptr;
+}
+
+// Live subscriptions, keyed the way the sender addressed them.
+static std::unordered_map<std::string, HOOK_ID> hookIds;
+static std::unordered_map<std::string, std::unordered_map<int32_t, HOOK_ID>> filteredHookIds;
+
+// MARK: - Actions
+
+static const char* OutcomeName(GIActionStatus status) {
+    switch (status) {
+        case GI_STATUS_APPLIED:
+            return "applied";
+        case GI_STATUS_FINISHED:
+            return "finished";
+        case GI_STATUS_CANCELLED:
+            return "cancelled";
+        case GI_STATUS_EXPIRED:
+            return "expired";
+        case GI_STATUS_IMPOSSIBLE:
+            return "impossible";
+    }
+    return "unknown";
+}
+
+static nlohmann::json DescribeAction(const GIActions::Definition& definition) {
+    nlohmann::json entry;
+    entry["name"] = definition.name;
+    entry["displayName"] = definition.displayName;
+    entry["timed"] = definition.IsTimed();
+    entry["defaultDuration"] = definition.defaultDuration;
+    entry["stacking"] = definition.stacking == GI_STACK_REFRESH ? "refresh" : "queue";
+    entry["valence"] = definition.valence == GI_VALENCE_POSITIVE   ? "positive"
+                       : definition.valence == GI_VALENCE_NEGATIVE ? "negative"
+                                                                   : "neutral";
+    entry["params"] = nlohmann::json::array();
+    for (const auto& spec : definition.schema) {
+        nlohmann::json param;
+        param["name"] = spec.name;
+        param["type"] = GIParamTypeName(spec.type);
+        param["required"] = spec.required;
+        if (spec.min.has_value()) {
+            param["min"] = *spec.min;
+        }
+        if (spec.max.has_value()) {
+            param["max"] = *spec.max;
+        }
+        if (spec.defaultValue.has_value()) {
+            std::visit([&param](auto&& value) { param["default"] = value; }, *spec.defaultValue);
+        }
+        entry["params"].push_back(param);
+    }
+    return entry;
+}
+
+// Queues an action and wires its answers back to the sender. Answers nothing itself: the reply
+// comes from onComplete once the action lands, or `fail` if it never got that far.
+template <typename Fail>
+static void ApplyAction(const nlohmann::json& payload, const GIActions::Definition& definition, Fail&& fail) {
+    GIParams params;
+    std::string error;
+    if (payload.contains("params") && !ParamsFromJson(payload["params"], params, error)) {
+        fail("bad params for '" + std::string(definition.name) + "': " + error, "invalid");
+        return;
+    }
+
+    auto action = definition.Build(std::move(params), &error);
+    if (!action.has_value()) {
+        fail(error, "invalid");
+        return;
+    }
+
+    if (payload.contains("duration")) {
+        // Only a timed action can take one, and it has to stay timed: overriding to 0 would run
+        // onStart -- which may install hooks -- and then never run onEnd, leaving the effect stuck
+        // on with nothing for action.remove to find.
+        int64_t duration = payload["duration"].get<int64_t>();
+        if (!definition.IsTimed() || duration <= 0 || duration > UINT32_MAX) {
+            fail("bad duration for '" + std::string(definition.name) +
+                     "': must be a positive frame count on a timed action",
+                 "invalid");
+            return;
+        }
+        action->duration = (uint32_t)duration;
+    }
+
+    int64_t expiresAfter = payload.value("expiresAfter", (int64_t)DEFAULT_EXPIRES_AFTER);
+    if (expiresAfter < 0 || expiresAfter > UINT32_MAX) {
+        fail("bad expiresAfter for '" + std::string(definition.name) + "': must be a frame count (0 waits forever)",
+             "invalid");
+        return;
+    }
+    action->expiresAfter = (uint32_t)expiresAfter;
+    // Session by default, since a Sail session outlives any one save -- but a sender tying a
+    // action to the file it was meant for can say so.
+    action->lifetime =
+        payload.value("lifetime", std::string("session")) == "save" ? GI_LIFETIME_SAVE : GI_LIFETIME_SESSION;
+
+    nlohmann::json id = payload["id"];
+    // The first word back answers the action, whatever it turned out to be -- applied, or expired
+    // without ever running. Only a timed action speaks twice, and its second word is unsolicited,
+    // so it's an unsolicited message rather than a second reply to the same id. A request merged
+    // into a running instance by GI_STACK_REFRESH only ever hears "applied": the instance keeps
+    // its original onComplete, so its action.ended goes to the id that started it.
+    action->onComplete = [id, replied = false](GIActionStatus status) mutable {
+        nlohmann::json message;
+        message["id"] = id;
+        message["type"] = replied ? "action.ended" : "result";
+        message["outcome"] = OutcomeName(status);
+        replied = true;
+        Sail::Instance->QueueOutgoingPacket(std::move(message));
+    };
+
+    GameInteractor::Instance->Queue(std::move(*action));
+}
+
+// Drops every game-hook subscription Sail opened for a connected server. Must run on the game
+// thread: unsubscribing mutates GameInteractor's hook registry, which the game thread walks every
+// frame.
+static void TearDownSubscriptions() {
+    for (auto& [hookName, hookId] : hookIds) {
+        if (const HookBinding* binding = FindHookBinding(hookName)) {
+            binding->unsubscribe(hookId);
+        }
+    }
+    hookIds.clear();
+
+    for (auto& [hookName, filtered] : filteredHookIds) {
+        const HookBinding* binding = FindHookBinding(hookName);
+        if (binding == nullptr) {
+            continue;
+        }
+        for (auto& [hookIdFilter, hookId] : filtered) {
+            binding->unsubscribeForId(hookId);
+        }
+    }
+    filteredHookIds.clear();
+}
+
+// The game-thread pump, registered for as long as Sail is enabled. Draining remote messages and
+// tearing subscriptions down when the link drops both mutate GameInteractor state, so they run here
+// rather than from the network thread's connect/disconnect callbacks, which would race the game
+// thread's own use of that state.
+static HOOK_ID sPumpHookId = 0;
+static bool sWasConnected = false;
+
+bool Sail::Enable() {
+    if (isEnabled) {
+        return true;
+    }
+
+    // Nothing enabled (bad host): no pump either, or it would sit registered with no thread behind
+    // it and a second Enable would stack another.
+    if (!Network::Enable(CVarGetString("gNetwork.Sail.Host", "127.0.0.1"),
+                         CVarGetInteger("gNetwork.Sail.Port", 43384))) {
+        return false;
+    }
+
+    // Registered on the game thread (Enable is only ever called from it). Packets the network
+    // thread queues before this line just wait in the queue for the pump's first run. The pump is
+    // a member-scope lambda so it can still reach the private OnIncomingJson.
+    sWasConnected = false;
+    sPumpHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
+        // A dropped connection means the server is gone, so drop its subscriptions. Edge-triggered
+        // off isConnected (set by the network thread) so it fires exactly once per disconnect.
+        bool connectedNow = Sail::Instance->isConnected;
+        if (sWasConnected && !connectedNow) {
+            TearDownSubscriptions();
+        }
+        sWasConnected = connectedNow;
+
+        std::queue<nlohmann::json> packetQueue;
+        Sail::Instance->SwapIncomingPacketQueue(packetQueue);
+        while (!packetQueue.empty()) {
+            Sail::Instance->OnIncomingJson(std::move(packetQueue.front()));
+            packetQueue.pop();
+        }
+    });
+
+    return true;
+}
+
+void Sail::Disable() {
+    if (!isEnabled) {
+        return;
+    }
+
+    // Stop the network thread first; then, still on the game thread, unregister the pump and drop
+    // any subscriptions it left behind.
+    Network::Disable();
+    GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameStateMainStart>(sPumpHookId);
+    sPumpHookId = 0;
+    TearDownSubscriptions();
+    sWasConnected = false;
+}
+
+void Sail::OnIncomingJson(nlohmann::json payload) {
+    nlohmann::json responsePayload;
+    responsePayload["type"] = "result";
+
+    // Every rejection logs the same reason it reports, so the sender is never left with a bare
+    // failure it can't act on.
+    auto fail = [&](const std::string& reason, const char* outcome = "invalid") {
+        SPDLOG_ERROR("[Sail] {}", reason);
+        responsePayload["outcome"] = outcome;
+        responsePayload["reason"] = reason;
+        QueueOutgoingPacket(responsePayload);
+    };
+    auto ok = [&]() {
+        responsePayload["outcome"] = "ok";
+        QueueOutgoingPacket(responsePayload);
+    };
+
+    try {
+        if (!payload.contains("id")) {
+            fail("received payload without ID");
+            return;
+        }
+
+        responsePayload["id"] = payload["id"];
+
+        if (!payload.contains("type")) {
+            fail("received payload without type");
+            return;
+        }
+
+        std::string payloadType = payload["type"].get<std::string>();
+
+        // A raw escape hatch into the debug console, and the only thing here that skips the queue
+        // entirely -- no readiness gate, no lifetime, and `ok` means "the string was dispatched"
+        // rather than "it worked". Some console commands (give_item, spawn, entrance) reach the
+        // game world just as directly as an action does; the action form of those is the one that
+        // waits its turn, so prefer it where it exists.
+        if (payloadType == "command") {
+            if (!payload.contains("command")) {
+                fail("received command payload without command");
+                return;
+            }
+
+            std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
+                Ship::Context::GetRawInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+                ->Dispatch(payload["command"].get<std::string>());
+            ok();
+            return;
+        } else if (payloadType == "action.apply" || payloadType == "action.remove") {
+            if (!payload.contains("name")) {
+                fail("received " + payloadType + " without a name");
+                return;
+            }
+
+            std::string name = payload["name"].get<std::string>();
+            const GIActions::Definition* definition = GIActions::FindByName(name);
+            if (definition == nullptr) {
+                fail("unknown action '" + name + "'", "impossible");
+                return;
+            }
+
+            // Ends every running instance of the action, firing its onEnd so nothing is left
+            // half-applied. `cancelled` says whether there was anything to stop.
+            if (payloadType == "action.remove") {
+                responsePayload["cancelled"] = GameInteractor::Instance->CancelAction(definition->id);
+                ok();
+                return;
+            }
+
+            ApplyAction(payload, *definition, fail);
+            return;
+        } else if (payloadType == "action.list") {
+            responsePayload["protocol"] = SAIL_PROTOCOL_VERSION;
+            responsePayload["actions"] = nlohmann::json::array();
+            for (const auto& definition : GIActions::All()) {
+                responsePayload["actions"].push_back(DescribeAction(definition));
+            }
+            ok();
+            return;
+        } else if (payloadType == "action.status") {
+            // Lets a sender hold something back until the player can actually receive it, rather
+            // than firing and waiting for an `expired`.
+            responsePayload["ready"] = GameInteractor::Instance->CanProcessActions() == GI_AVAILABILITY_READY;
+            responsePayload["pending"] = GameInteractor::Instance->PendingActions().size();
+            responsePayload["active"] = GameInteractor::Instance->ActiveActions().size();
+            ok();
+            return;
+        } else if (payloadType == "hook.list") {
+            responsePayload["hooks"] = nlohmann::json::array();
+            for (const auto& binding : HookBindings()) {
+                responsePayload["hooks"].push_back({ { "name", binding.name }, { "idFilter", binding.idFilter } });
+            }
+            ok();
+            return;
+        } else if (payloadType == "subscribe" || payloadType == "unsubscribe") {
+            if (!payload.contains("hookName")) {
+                fail("received " + payloadType + " without hookName");
+                return;
+            }
+
+            std::string hookName = payload["hookName"].get<std::string>();
+            const HookBinding* binding = FindHookBinding(hookName);
+            if (binding == nullptr) {
+                fail("unknown hookName '" + hookName + "'", "impossible");
+                return;
+            }
+
+            bool byId = payload.contains("hookIdFilter");
+            if (byId && !binding->idFilter) {
+                // Registering it filtered would attach to a hook nothing dispatches by id, so it
+                // would just never fire. Say so rather than going quiet.
+                fail("hookName '" + hookName + "' does not support hookIdFilter", "impossible");
+                return;
+            }
+            int32_t hookIdFilter = byId ? payload["hookIdFilter"].get<int32_t>() : 0;
+
+            if (payloadType == "subscribe") {
+                if (byId) {
+                    if (!filteredHookIds[hookName].contains(hookIdFilter)) {
+                        filteredHookIds[hookName][hookIdFilter] = binding->subscribeForId(hookIdFilter);
+                    }
+                } else if (!hookIds.contains(hookName)) {
+                    hookIds[hookName] = binding->subscribe();
+                }
+            } else if (byId) {
+                auto it = filteredHookIds[hookName].find(hookIdFilter);
+                if (it != filteredHookIds[hookName].end()) {
+                    binding->unsubscribeForId(it->second);
+                    filteredHookIds[hookName].erase(it);
+                }
+            } else {
+                auto it = hookIds.find(hookName);
+                if (it != hookIds.end()) {
+                    binding->unsubscribe(it->second);
+                    hookIds.erase(it);
+                }
+            }
+
+            ok();
+            return;
+        } else {
+            fail("unknown payload type '" + payloadType + "'", "impossible");
+            return;
+        }
+    } catch (const std::exception& e) {
+        // Usually a field of the wrong JSON type. The sender is still owed an answer for this id;
+        // going quiet here would leave it waiting forever.
+        fail(std::string("exception handling message: ") + e.what());
+    } catch (...) { fail("unknown exception handling message"); }
+}

--- a/mm/2s2h/Network/Sail/Sail.h
+++ b/mm/2s2h/Network/Sail/Sail.h
@@ -1,0 +1,19 @@
+#ifndef NETWORK_SAIL_H
+#define NETWORK_SAIL_H
+#ifdef __cplusplus
+
+#include "2s2h/Network/Network.h"
+
+class Sail : public Network {
+  private:
+    void OnIncomingJson(nlohmann::json payload);
+
+  public:
+    static Sail* Instance;
+
+    bool Enable();
+    void Disable();
+};
+
+#endif // __cplusplus
+#endif // NETWORK_SAIL_H

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -133,7 +133,6 @@ void Rando::ActorBehavior::OnFileLoad() {
     Rando::ActorBehavior::InitObjWarpstoneBehavior();
     Rando::ActorBehavior::InitPlayerBehavior();
     Rando::ActorBehavior::InitSoulsBehavior();
-    Rando::ActorBehavior::InitTrapsBehavior();
     Rando::ActorBehavior::InitWonderItemsBehavior();
 
     COND_HOOK(ShouldVanillaBehavior, IS_RANDO, MiscVanillaBehaviorHandler);

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
@@ -105,7 +105,6 @@ void InitObjTsuboBehavior();
 void InitObjWarpstoneBehavior();
 void InitPlayerBehavior();
 void InitSoulsBehavior();
-void InitTrapsBehavior();
 void InitWonderItemsBehavior();
 
 } // namespace ActorBehavior

--- a/mm/2s2h/Rando/GiveItem.cpp
+++ b/mm/2s2h/Rando/GiveItem.cpp
@@ -1,4 +1,5 @@
 #include "Rando/Rando.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 #include "Rando/ActorBehavior/Souls.h"
 #include "Rando/MiscBehavior/MiscBehavior.h"
 #include "Rando/MiscBehavior/ClockShuffle.h"
@@ -135,11 +136,10 @@ void Rando::GiveItem(RandoItemId randoItemId) {
                     Rando::GiveItem(RI_SOUL_BOSS_MAJORA);
                 }
                 GameInteractor_ExecuteOnGameCompletion();
-                GameInteractor::Instance->events.emplace_back(
-                    GIEventTransition{ .entrance = ENTRANCE(TERMINA_FIELD, 0),
-                                       .cutsceneIndex = 0xFFF7,
-                                       .transitionTrigger = TRANS_TRIGGER_START,
-                                       .transitionType = TRANS_TYPE_FADE_BLACK });
+                GameInteractor::Instance->Queue(GIActions::Transition({ .entrance = ENTRANCE(TERMINA_FIELD, 0),
+                                                                        .cutsceneIndex = 0xFFF7,
+                                                                        .transitionTrigger = TRANS_TRIGGER_START,
+                                                                        .transitionType = TRANS_TYPE_FADE_BLACK }));
             }
             break;
         // Technically these should never be used, but leaving them here just in case

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -6,6 +6,7 @@
 #include "2s2h/BenGui/Notification.h"
 #include "2s2h/Rando/StaticData/StaticData.h"
 #include "2s2h/ShipUtils.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 #include "Traps.h"
 
 extern "C" {
@@ -32,92 +33,99 @@ void Rando::MiscBehavior::CheckQueue() {
     }
 
     for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
-        auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
+        auto& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
 
         if (randoSaveCheck.eligible) {
             queued = true;
 
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                .showGetItemCutscene =
-                    Rando::StaticData::ShouldShowGetItemCutscene(ConvertItem(randoSaveCheck.randoItemId, randoCheckId)),
-                .param = (int16_t)randoCheckId,
-                .giveItem =
-                    [](Actor* actor, PlayState* play) {
-                        auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
-                        RandoItemId randoItemId =
-                            Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
-                        std::string prefix = "You found";
-                        std::string message =
-                            Rando::StaticData::GetItemName(randoItemId, true, (RandoCheckId)CUSTOM_ITEM_PARAM);
+            GameInteractor::Instance->Queue(
+                GIActions::GiveItem(
+                    { .showGetItemCutscene = Rando::StaticData::ShouldShowGetItemCutscene(
+                          ConvertItem(randoSaveCheck.randoItemId, randoCheckId)),
+                      .param = (int16_t)randoCheckId,
+                      .giveItem =
+                          [](Actor* actor, PlayState* play) {
+                              auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
+                              RandoItemId randoItemId =
+                                  Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
+                              std::string prefix = "You found";
+                              std::string message =
+                                  Rando::StaticData::GetItemName(randoItemId, true, (RandoCheckId)CUSTOM_ITEM_PARAM);
 
-                        if (randoItemId == RI_JUNK) {
-                            randoItemId = Rando::CurrentJunkItem((RandoCheckId)CUSTOM_ITEM_PARAM);
-                        }
-                        if (randoItemId == RI_TRIFORCE_PIECE) {
-                            if (gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces + 1 >=
-                                RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED]) {
-                                prefix = "You";
-                                message = "completed the Triforce";
-                            }
-                            randoItemId = RI_TRIFORCE_PIECE_PREVIOUS;
-                        }
+                              if (randoItemId == RI_JUNK) {
+                                  randoItemId = Rando::CurrentJunkItem((RandoCheckId)CUSTOM_ITEM_PARAM);
+                              }
+                              if (randoItemId == RI_TRIFORCE_PIECE) {
+                                  if (gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces + 1 >=
+                                      RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED]) {
+                                      prefix = "You";
+                                      message = "completed the Triforce";
+                                  }
+                                  randoItemId = RI_TRIFORCE_PIECE_PREVIOUS;
+                              }
 
-                        if (randoItemId == RI_TRAP) {
-                            prefix = "";
-                            message = GetTrapMessage();
-                            // We need to remove the Color Codes if the player is skipping Item Get Cutscenes as the
-                            // Notification Emit doesnt support it.
-                            if (CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0) >= 2) {
-                                message = CustomMessage::RemoveColorCodes(message);
-                            }
-                        }
+                              if (randoItemId == RI_TRAP) {
+                                  // Roll first, then describe what was rolled. Rando::GiveItem(RI_TRAP)
+                                  // below queues whatever this landed on, so both have to agree.
+                                  RollTrapType();
+                                  prefix = "";
+                                  message = GetTrapMessage();
+                                  // We need to remove the Color Codes if the player is skipping Item Get Cutscenes as
+                                  // the Notification Emit doesnt support it.
+                                  if (CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0) >= 2) {
+                                      message = CustomMessage::RemoveColorCodes(message);
+                                  }
+                              }
 
-                        CustomMessage::Entry entry = {
-                            .textboxType = 2,
-                            .icon = Rando::StaticData::GetIconForZMessage(randoItemId),
-                            .msg = (prefix == "" ? "" : prefix + " ") + message + (randoItemId == RI_TRAP ? "" : "!"),
-                        };
+                              CustomMessage::Entry entry = {
+                                  .textboxType = 2,
+                                  .icon = Rando::StaticData::GetIconForZMessage(randoItemId),
+                                  .msg = (prefix == "" ? "" : prefix + " ") + message +
+                                         (randoItemId == RI_TRAP ? "" : "!"),
+                              };
 
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                            CustomMessage::SetActiveCustomMessage(entry.msg, entry);
-                        } else if (Rando::StaticData::ShouldShowGetItemCutscene(randoItemId)) {
-                            CustomMessage::StartTextbox(entry.msg + "\x1C\x02\x10", entry);
-                        } else {
-                            if (Rando::StaticData::Items[randoItemId].randoItemType != RITYPE_JUNK) {
-                                Notification::Emit({
-                                    .itemIcon = Rando::StaticData::GetIconTexturePath(randoItemId),
-                                    .message = prefix,
-                                    .suffix = message,
-                                });
-                            }
-                        }
-                        Rando::GiveItem(randoItemId);
-                        randoSaveCheck.cycleObtained = true;
-                        randoSaveCheck.obtained = true;
-                        randoSaveCheck.eligible = false;
-                        queued = false;
-                        CUSTOM_ITEM_PARAM = randoItemId;
-                    },
-                .drawItem =
-                    [](Actor* actor, PlayState* play) {
-                        RandoItemId randoItemId;
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                                  CustomMessage::SetActiveCustomMessage(entry.msg, entry);
+                              } else if (Rando::StaticData::ShouldShowGetItemCutscene(randoItemId)) {
+                                  CustomMessage::StartTextbox(entry.msg + "\x1C\x02\x10", entry);
+                              } else {
+                                  if (Rando::StaticData::Items[randoItemId].randoItemType != RITYPE_JUNK) {
+                                      Notification::Emit({
+                                          .itemIcon = Rando::StaticData::GetIconTexturePath(randoItemId),
+                                          .message = prefix,
+                                          .suffix = message,
+                                      });
+                                  }
+                              }
+                              Rando::GiveItem(randoItemId);
+                              randoSaveCheck.cycleObtained = true;
+                              randoSaveCheck.obtained = true;
+                              randoSaveCheck.eligible = false;
+                              CUSTOM_ITEM_PARAM = randoItemId;
+                          },
+                      .drawItem =
+                          [](Actor* actor, PlayState* play) {
+                              RandoItemId randoItemId;
 
-                        // If the item has been given, the CUSTOM_ITEM_PARAM is set to the RI, prior to that it's the RC
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION) {
-                            if ((RandoItemId)CUSTOM_ITEM_PARAM == RI_TRAP) {
-                                randoItemId = RI_MAX_TRAP;
-                            } else {
-                                randoItemId = (RandoItemId)CUSTOM_ITEM_PARAM;
-                            }
-                        } else {
-                            auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
-                            randoItemId =
-                                Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
-                        }
+                              // If the item has been given, the CUSTOM_ITEM_PARAM is set to the RI, prior to that it's
+                              // the RC
+                              if (CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION) {
+                                  if ((RandoItemId)CUSTOM_ITEM_PARAM == RI_TRAP) {
+                                      randoItemId = RI_MAX_TRAP;
+                                  } else {
+                                      randoItemId = (RandoItemId)CUSTOM_ITEM_PARAM;
+                                  }
+                              } else {
+                                  auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
+                                  randoItemId =
+                                      Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
+                              }
 
-                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
-                    } });
+                              Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                              Rando::DrawItem(randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
+                          } })
+                    // Delivered or dropped, this is the one place the latch comes off.
+                    .OnComplete([](GIActionStatus status) { queued = false; }));
             return;
         }
     }
@@ -125,6 +133,4 @@ void Rando::MiscBehavior::CheckQueue() {
 
 void Rando::MiscBehavior::CheckQueueReset() {
     queued = false;
-    GameInteractor::Instance->currentEvent = GIEventNone{};
-    GameInteractor::Instance->events.clear();
 }

--- a/mm/2s2h/Rando/MiscBehavior/Traps.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/Traps.cpp
@@ -1,53 +1,39 @@
 #include "Traps.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "MiscBehavior.h"
-#include "Rando/ActorBehavior/ActorBehavior.h"
-#include "2s2h/DeveloperTools/SaveEditor.h"
-#include "2s2h/ShipUtils.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/GameInteractor/Actions/Actions.h"
 
-extern "C" {
-#include "variables.h"
-#include "functions.h"
-#include "overlays/actors/ovl_En_Time_Tag/z_en_time_tag.h"
-void func_80833B18(PlayState* play, Player* thisx, s32 arg2, f32 speed, f32 velocityY, s16 arg5,
-                   s32 invincibilityTimer);
-void EnTimeTag_KickOut_Transition(EnTimeTag* enTimeTag, PlayState* play);
-}
+static GIActionId currentTrap = GI_ACTION_FREEZE;
 
-extern void UpdateGameTime(u16 gameTime);
-
-int roll = TRAP_FREEZE;
-const u16 timeSkipInterval = 4000;
-
-std::map<TrapTypes, const char*> trapToCvarMap = {
-    { TRAP_FREEZE, "gRando.Traps.Freeze" },      { TRAP_BLAST, "gRando.Traps.Blast" },
-    { TRAP_SHOCK, "gRando.Traps.Shock" },        { TRAP_JINX, "gRando.Traps.Jinx" },
-    { TRAP_WALLET, "gRando.Traps.Wallet" },      { TRAP_ENEMY, "gRando.Traps.Enemy" },
-    { TRAP_TIME, "gRando.Traps.Time" },          { TRAP_FIRE, "gRando.Traps.Fire" },
-    { TRAP_KNOCKBACK, "gRando.Traps.Knockback" }
+static const std::map<GIActionId, const char*> trapToCvarMap = {
+    { GI_ACTION_FREEZE, "gRando.Traps.Freeze" },       { GI_ACTION_BLAST, "gRando.Traps.Blast" },
+    { GI_ACTION_SHOCK, "gRando.Traps.Shock" },         { GI_ACTION_JINX, "gRando.Traps.Jinx" },
+    { GI_ACTION_EMPTY_WALLET, "gRando.Traps.Wallet" }, { GI_ACTION_SPAWN_LIKE_LIKE, "gRando.Traps.Enemy" },
+    { GI_ACTION_SKIP_TIME, "gRando.Traps.Time" },      { GI_ACTION_BURN, "gRando.Traps.Fire" },
+    { GI_ACTION_KNOCKBACK, "gRando.Traps.Knockback" },
 };
 
-std::vector<TrapTypes> getEnabledTrapTypes() {
-    std::vector<TrapTypes> enabledTrapTypes;
+static std::vector<GIActionId> GetEnabledTrapTypes() {
+    std::vector<GIActionId> enabledTrapTypes;
     for (auto& trap : trapToCvarMap) {
         if (CVarGetInteger(trap.second, 0)) {
             enabledTrapTypes.push_back(trap.first);
         }
     }
     if (enabledTrapTypes.size() == 0) {
-        enabledTrapTypes.push_back(TRAP_FREEZE);
+        enabledTrapTypes.push_back(GI_ACTION_FREEZE);
     }
     return enabledTrapTypes;
-};
+}
 
-int RollTrapType() {
-    auto enabledTraps = getEnabledTrapTypes();
-    roll = enabledTraps[rand() % enabledTraps.size()];
-    return roll;
+void RollTrapType() {
+    auto enabledTraps = GetEnabledTrapTypes();
+    currentTrap = enabledTraps[rand() % enabledTraps.size()];
 }
 
 // clang-format off
-std::vector<std::string> defaultTrapMessages = { 
+std::vector<std::string> defaultTrapMessages = {
     "This item is available in the %bRando DLC%w.",
     "This is what happens when %gCaladius%w is left unsupervised.",
     "Oh no!",
@@ -119,27 +105,25 @@ std::vector<std::string> timeTrapMessages = {
     "Mweep",
 };
 
-std::map<TrapTypes, std::vector<std::string>> trapMessageList = {
-    { TRAP_FREEZE, freezeTrapMessages },
-    { TRAP_BLAST, blastTrapMessages },
-    { TRAP_SHOCK, shockTrapMessages },
-    { TRAP_JINX, jinxTrapMessages },
-    { TRAP_WALLET, walletTrapMessages },
-    { TRAP_ENEMY, enemyTrapMessages },
-    { TRAP_TIME, timeTrapMessages },
-    { TRAP_FIRE, defaultTrapMessages },
-    { TRAP_KNOCKBACK, defaultTrapMessages },
+std::map<GIActionId, std::vector<std::string>> trapMessageList = {
+    { GI_ACTION_FREEZE, freezeTrapMessages },
+    { GI_ACTION_BLAST, blastTrapMessages },
+    { GI_ACTION_SHOCK, shockTrapMessages },
+    { GI_ACTION_JINX, jinxTrapMessages },
+    { GI_ACTION_EMPTY_WALLET, walletTrapMessages },
+    { GI_ACTION_SPAWN_LIKE_LIKE, enemyTrapMessages },
+    { GI_ACTION_SKIP_TIME, timeTrapMessages },
+    { GI_ACTION_BURN, defaultTrapMessages },
+    { GI_ACTION_KNOCKBACK, defaultTrapMessages },
 };
 // clang-format on
 
 std::string GetTrapMessage() {
-    RollTrapType();
-    auto findIt = trapMessageList.find((TrapTypes)roll);
+    auto findIt = trapMessageList.find(currentTrap);
     if (findIt == trapMessageList.end()) {
         return defaultTrapMessages[rand() % defaultTrapMessages.size()];
-    } else {
-        return findIt->second[rand() % findIt->second.size()];
     }
+    return findIt->second[rand() % findIt->second.size()];
 }
 
 void Rando::MiscBehavior::OfferTrapItem() {
@@ -147,174 +131,12 @@ void Rando::MiscBehavior::OfferTrapItem() {
         return;
     }
 
-    switch (roll) {
-        case TRAP_FREEZE:
-            GameInteractor::Instance->events.emplace_back(
-                GIEventTrap{ .action = []() { func_80833B18(gPlayState, GET_PLAYER(gPlayState), 3, 0, 0, 0, 0); } });
-            break;
-        case TRAP_BLAST:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                GET_PLAYER(gPlayState)->actor.colChkInfo.damage = 16;
-                func_80833B18(gPlayState, GET_PLAYER(gPlayState), 2, 0, 0, 0, 0);
-                Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_BOM, GET_PLAYER(gPlayState)->actor.world.pos.x,
-                            GET_PLAYER(gPlayState)->actor.world.pos.y, GET_PLAYER(gPlayState)->actor.world.pos.z, 1, 0,
-                            0, 0);
-            } });
-            break;
-        case TRAP_SHOCK:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                GET_PLAYER(gPlayState)->actor.colChkInfo.damage = 16;
-                func_80833B18(gPlayState, GET_PLAYER(gPlayState), 4, 0, 0, 0, 0);
-            } });
-            break;
-        case TRAP_FIRE:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                Player* player = GET_PLAYER(gPlayState);
-                for (int i = 0; i < 18; i++) {
-                    player->bodyFlameTimers[i] = static_cast<uint8_t>(Rand_S16Offset(0, 200));
-                }
-                player->bodyIsBurning = true;
-                func_80833B18(gPlayState, player, 0, 0, 0, 0, 0);
-            } });
-            break;
-        case TRAP_KNOCKBACK:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                Player* player = GET_PLAYER(gPlayState);
-                float strength = 4;
-                func_800B8D98(gPlayState, &player->actor, strength * 5, player->actor.world.rot.y + 0x8000,
-                              strength * 5);
-
-                static HOOK_ID knockbackBounceHook = 0;
-                GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(knockbackBounceHook);
-                knockbackBounceHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(
-                    ACTOR_PLAYER, [](Actor* actor) {
-                        Player* player = (Player*)actor;
-                        if (player->actor.bgCheckFlags & 0x08 && abs(player->speedXZ) > 15.0f) {
-                            player->yaw = ((player->actor.wallYaw - player->yaw) + player->actor.wallYaw) - 0x8000;
-                            Player_PlaySfx(player, NA_SE_PL_BODY_HIT);
-                        }
-
-                        if (player->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-                            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(
-                                knockbackBounceHook);
-                        }
-                    });
-            } });
-            break;
-        case TRAP_JINX:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                Actor_PlaySfx(&GET_PLAYER(gPlayState)->actor, NA_SE_EN_BUBLE_BITE);
-                gSaveContext.jinxTimer = 1200;
-            } });
-            break;
-        case TRAP_WALLET:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                int16_t currentRupees = gSaveContext.save.saveInfo.playerData.rupees;
-                if (currentRupees != 0) {
-                    Vec3f positional = GET_PLAYER(gPlayState)->actor.world.pos;
-                    positional.y = GET_PLAYER(gPlayState)->actor.world.pos.y + 100.0f;
-                    Item00Type rupee = ITEM00_RUPEE_GREEN;
-                    int16_t spawnedRupees = 0;
-                    int16_t remainingRupees = currentRupees;
-                    for (int i = spawnedRupees; spawnedRupees < remainingRupees;) {
-                        if (currentRupees >= 20) {
-                            rupee = ITEM00_RUPEE_RED;
-                            spawnedRupees += 20;
-                            Rupees_ChangeBy(-20);
-                            currentRupees -= 20;
-                        } else if (currentRupees >= 5) {
-                            rupee = ITEM00_RUPEE_BLUE;
-                            spawnedRupees += 5;
-                            Rupees_ChangeBy(-5);
-                            currentRupees -= 5;
-                        } else if (currentRupees >= 1) {
-                            rupee = ITEM00_RUPEE_GREEN;
-                            spawnedRupees += 1;
-                            Rupees_ChangeBy(-1);
-                            currentRupees -= 1;
-                        }
-                        EnItem00* rupeeActor = (EnItem00*)Item_DropCollectible(gPlayState, &positional, rupee);
-                        rupeeActor->actor.speed = Rand_CenteredFloat(5.0f);
-                        rupeeActor->unk152 = 600; // Extending Time before Despawning
-                    }
-                }
-            } });
-            break;
-        case TRAP_ENEMY:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_RR, GET_PLAYER(gPlayState)->actor.world.pos.x,
-                            GET_PLAYER(gPlayState)->actor.world.pos.y, GET_PLAYER(gPlayState)->actor.world.pos.z, 0, 0,
-                            0, 1);
-            } });
-            break;
-        case TRAP_TIME:
-            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
-                u16 previous_time = gSaveContext.save.time;
-                u16 new_time = gSaveContext.save.time + timeSkipInterval;
-                if (previous_time < MORNING_TIME && new_time >= MORNING_TIME) {
-                    // Handles case where Night -> Day
-                    if (gSaveContext.save.day != 3) {
-                        gSaveContext.save.day++;
-                        gSaveContext.save.eventDayCount++;
-                        UpdateGameTime(new_time);
-                        Interface_NewDay(gPlayState, CURRENT_DAY);
-                        // Load environment values for new day
-                        Environment_NewDay(&gPlayState->envCtx);
-                        // Clear weather from day 2
-                        gWeatherMode = WEATHER_MODE_CLEAR;
-                        gPlayState->envCtx.lightningState = LIGHTNING_OFF;
-                    } else {
-                        // Handles Moonfall case, prevents skipping past it by setting time right before Moonfall.
-                        UpdateGameTime(MORNING_TIME - (timeSkipInterval / 10));
-                    }
-                } else {
-                    // Every other case
-                    UpdateGameTime(new_time);
-                }
-                TransitionFade_SetColor(&gPlayState->unk_18E48, 0x000000);
-                R_TRANS_FADE_FLASH_ALPHA_STEP = -1;
-                Player_PlaySfx(GET_PLAYER(gPlayState), NA_SE_SY_TRANSFORM_MASK_FLASH);
-
-                // Handle kickouts, if needed
-                EnTimeTag* enTimeTag = (EnTimeTag*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
-                                                                    ACTOR_EN_TIME_TAG, ACTORCAT_ITEMACTION, 99999.9f);
-                if (enTimeTag != nullptr) {
-                    TimeTagType timeTagType = (TimeTagType)TIMETAG_GET_TYPE(&enTimeTag->actor);
-                    if (timeTagType == TIMETAG_KICKOUT_DOOR || timeTagType >= TIMETAG_KICKOUT_FINAL_HOURS) {
-                        s16 kickoutHour = TIMETAG_KICKOUT_HOUR(&enTimeTag->actor);
-                        s16 kickoutMinute = TIMETAG_KICKOUT_MINUTE(&enTimeTag->actor);
-                        s32 kickoutTime = CLOCK_TIME(kickoutHour, kickoutMinute);
-                        kickoutTime = ZERO_DAY_START(kickoutTime);
-                        previous_time = ZERO_DAY_START(previous_time);
-                        new_time = ZERO_DAY_START(new_time);
-                        // If we were here before the kickout time, and now it's after, then get out of my house
-                        if (previous_time <= kickoutTime && new_time >= kickoutTime) {
-                            // Unless this is the Stock Pot Inn, and the room key is obtained
-                            if (!(gPlayState->sceneId == SCENE_YADOYA &&
-                                  Flags_GetRandoInf(RANDO_INF_OBTAINED_ROOM_KEY))) {
-                                // This comes from EnTimeTag_KickOut_WaitForTime
-                                Player_SetCsActionWithHaltedActors(gPlayState, &enTimeTag->actor, PLAYER_CSACTION_WAIT);
-                                Message_StartTextbox(gPlayState, 0x1883 + TIMETAG_KICKOUT_GET_TEXT(&enTimeTag->actor),
-                                                     NULL);
-                                enTimeTag->actionFunc = EnTimeTag_KickOut_Transition;
-                            }
-                        }
-                    }
-                }
-            } });
-            break;
-        default:
-            break;
+    const GIActions::Definition* definition = GIActions::Get(currentTrap);
+    if (definition == nullptr) {
+        return;
     }
-}
 
-void Rando::ActorBehavior::InitTrapsBehavior() {
-    // Selectively disable object dependency for actors spawned by traps
-    COND_VB_SHOULD(VB_ENABLE_OBJECT_DEPENDENCY, IS_RANDO && RANDO_SAVE_OPTIONS[RO_SHUFFLE_TRAPS], {
-        ObjectId objectId = (ObjectId)va_arg(args, int);
-        // Allow spawning of like-like & shield so it drops from like-like
-        if (objectId == OBJECT_RR || objectId == OBJECT_GI_SHIELD_2) {
-            *should = false;
-        }
-    });
+    if (auto request = definition->Build({})) {
+        GameInteractor::Instance->Queue(std::move(*request));
+    }
 }

--- a/mm/2s2h/Rando/MiscBehavior/Traps.h
+++ b/mm/2s2h/Rando/MiscBehavior/Traps.h
@@ -2,20 +2,11 @@
 #define RANDO_TRAP_H
 
 #include "Rando/Rando.h"
-typedef enum {
-    TRAP_FREEZE,
-    TRAP_BLAST,
-    TRAP_SHOCK,
-    TRAP_JINX,
-    TRAP_WALLET,
-    TRAP_ENEMY,
-    TRAP_TIME,
-    TRAP_FIRE,
-    TRAP_KNOCKBACK,
-    TRAP_MAX
-} TrapTypes;
+#include "2s2h/GameInteractor/GameInteractorAction.h"
 
-extern int RollTrapType();
-extern std::string GetTrapMessage();
+// Picks the next trap from the enabled pool and remembers it, so that GetTrapMessage() and the
+// eventual OfferTrapItem() agree on what the player is getting.
+void RollTrapType();
+std::string GetTrapMessage();
 
 #endif

--- a/mm/2s2h/Rando/Rando.h
+++ b/mm/2s2h/Rando/Rando.h
@@ -1,6 +1,8 @@
 #ifndef RANDO_H
 #define RANDO_H
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "StaticData/StaticData.h"
 #include "Types.h"
 #include "variables.h"

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -428,6 +428,10 @@ std::string GetActorCategoryName(u8 category) {
     return "Unknown";
 }
 
+bool IsStringEmpty(const std::string& str) {
+    return str.find_first_not_of(' ') == std::string::npos;
+}
+
 extern "C" {
 Vtx sCycleExtraItemVtx[8] = {
     // Left Item

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -31,6 +31,7 @@ extern uint32_t Ship_Hash(std::string str);
 extern std::string GetActorDescription(u16 actorNum);
 extern std::string GetActorDebugName(u16 actorNum);
 extern std::string GetActorCategoryName(u8 category);
+bool IsStringEmpty(const std::string& str);
 
 extern "C" {
 #endif

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -113,6 +113,11 @@ endif()
 
 list(FILTER ship__ EXCLUDE REGEX "2s2h/Extractor/*")
 
+option(SKIP_NETWORKING "Skip networking support (Sail remote control), avoiding the SDL2_net 2.2.0 dependency" OFF)
+if (SKIP_NETWORKING)
+    list(FILTER ship__ EXCLUDE REGEX "2s2h/Network/*")
+endif()
+
 if(NOT CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
     file(GLOB_RECURSE ship__Extractor RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
         "2s2h/Extractor/*.c"
@@ -223,8 +228,8 @@ endif()
 find_package(SDL2)
 set(SDL2-INCLUDE ${SDL2_INCLUDE_DIRS})
 
-if (BUILD_CROWD_CONTROL)
-    find_package(SDL2_net)
+if (NOT SKIP_NETWORKING)
+    find_package(SDL2_net 2.2.0 REQUIRED)
     set(SDL2-NET-INCLUDE ${SDL_NET_INCLUDE_DIRS})
 endif()
 
@@ -253,9 +258,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		"$<$<CONFIG:Release>:"
 			"NDEBUG;"
 		">"
-           #"$<$<BOOL:${BUILD_CROWD_CONTROL}>:ENABLE_CROWD_CONTROL>"
 		"INCLUDE_GAME_PRINTF;"
-           #"ENABLE_CROWD_CONTROL;"
 		"F3DEX_GBI_2"
 		"UNICODE;"
 		"_UNICODE"
@@ -289,7 +292,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
 			"NDEBUG;"
 		">"
         "F3DEX_GBI_2;"
-		# "$<$<BOOL:${BUILD_CROWD_CONTROL}>:ENABLE_CROWD_CONTROL>"
 		"_CONSOLE;"
 		"_CRT_SECURE_NO_WARNINGS;"
 		"ENABLE_OPENGL;"
@@ -560,7 +562,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		"glu32;"
 		"SDL2::SDL2;"
 		"SDL2::SDL2main;"
-        #"$<$<BOOL:${BUILD_CROWD_CONTROL}>:SDL2_net::SDL2_net-static>"
+        "$<$<NOT:$<BOOL:${SKIP_NETWORKING}>>:SDL2_net::SDL2_net-static>"
 		"glfw;"
 		"winmm;"
 		"imm32;"
@@ -613,7 +615,7 @@ else()
         "Opus::opus"
         "Opusfile::Opusfile"
 		SDL2::SDL2
- #       "$<$<BOOL:${BUILD_CROWD_CONTROL}>:SDL2_net::SDL2_net>"
+        "$<$<NOT:$<BOOL:${SKIP_NETWORKING}>>:SDL2_net::SDL2_net>"
 		${CMAKE_DL_LIBS}
 		Threads::Threads
 	)

--- a/mm/src/code/z_camera.c
+++ b/mm/src/code/z_camera.c
@@ -285,6 +285,9 @@ f32 Camera_GetFocalActorHeight(Camera* camera) {
 
     if (focalActor == &GET_PLAYER(camera->play)->actor) {
         focalActorHeight = Player_GetHeight((Player*)focalActor);
+        // #region 2S2H [Enhancement] Let effects that resize the player bring the camera with them
+        GameInteractor_Should(VB_MODIFY_CAMERA_FOCAL_HEIGHT, true, &focalActorHeight);
+        // #endregion
     } else {
         focalActorFocus = Actor_GetFocus(focalActor);
         focalActorHeight = focalActorFocus.pos.y - camera->focalActorPosRot.pos.y;

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -2170,8 +2170,9 @@ void Player_AdjustSingleLeg(PlayState* play, Player* player, SkelAnime* skelAnim
     f32 sp70;
     f32 sp7C;
 
-    if ((player->stateFlags3 & PLAYER_STATE3_1) || !(player->actor.scale.y >= 0.0f) ||
-        (player->stateFlags1 & PLAYER_STATE1_DEAD) || play->soaringCsOrSoTCsPlaying) {
+    if (GameInteractor_Should(VB_NOT_ADJUST_PLAYER_LEGS,
+                              (player->stateFlags3 & PLAYER_STATE3_1) || !(player->actor.scale.y >= 0.0f) ||
+                                  (player->stateFlags1 & PLAYER_STATE1_DEAD) || play->soaringCsOrSoTCsPlaying)) {
         return;
     }
 


### PR DESCRIPTION
A ground up rewrite from SoH's impl. Includes the GI Action system (which replaces some patterns we had on SoH and some patterns we were starting here for rando traps)

Intended to be used with the Sail companion app, or your own usage of the sail protocol.

### Companion App Downloads
- **Linux** — [AppImage](https://github.com/HarbourMasters/Sail/releases/download/nightly/Sail-x86_64.AppImage) (recommended) or the [raw binary](https://github.com/HarbourMasters/Sail/releases/download/nightly/Sail-linux-amd64.tar.gz)
- **macOS** — [universal `.app`](https://github.com/HarbourMasters/Sail/releases/download/nightly/Sail-macos-universal.zip)
- **Windows** — [portable `.exe`](https://github.com/HarbourMasters/Sail/releases/download/nightly/Sail-windows-amd64.exe)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/2ship2harkinian/2ship2harkinian/actions/artifacts/9848365745.zip)
  - [2ship-mac.zip](https://nightly.link/2ship2harkinian/2ship2harkinian/actions/artifacts/9848309025.zip)
  - [2ship-windows.zip](https://nightly.link/2ship2harkinian/2ship2harkinian/actions/artifacts/9848184920.zip)
<!--- section:artifacts:end -->