### PR TITLE
[Enhancement] Disable Magic Drops with Chateau

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -160,6 +160,12 @@ static const std::unordered_map<int32_t, const char*> damageMultiplierOptions = 
     { 0, "1x" }, { 1, "2x" }, { 2, "4x" }, { 3, "8x" }, { 4, "16x" }, { 10, "1 Hit KO" },
 };
 
+static const std::vector<const char*> disableMagicDropsOptions = {
+    "Off",
+    "Recovery Heart",
+    "Green Rupee",
+};
+
 namespace BenGui {
 extern std::shared_ptr<BenMenu> mBenMenu;
 void FreeLookPitchMinMax() {
@@ -1112,11 +1118,12 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Oceanside wallet any day", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cycle.OceansideWalletAnyDay")
         .Options(CheckboxOptions().Tooltip("Allows the wallet reward to be collected on any day."));
-    AddWidget(path, "Disable Magic Drops with Chateau Romani", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Disable Magic Drops with Chateau Romani", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Cycle.DisableMagicDropsWithChateau")
-        .Options(CheckboxOptions().Tooltip(
-            "When Chateau Romani is active, Magic Jar drops are replaced with Recovery Hearts (which become Rupees "
-            "if health is full)."));
+        .Options(ComboboxOptions()
+                     .Tooltip("When Chateau Romani is active, Magic Jar drops are replaced.")
+                     .DefaultIndex(DisableMagicDropsOptions::DISABLE_MAGIC_DROPS_OFF)
+                     .ComboVec(&disableMagicDropsOptions));
     AddWidget(path, "Unstable", WIDGET_SEPARATOR_TEXT).Options(WidgetOptions().Color(Colors::Orange));
     AddWidget(path, "Disable Save Delay", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Saving.DisableSaveDelay")

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1112,6 +1112,11 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Oceanside wallet any day", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cycle.OceansideWalletAnyDay")
         .Options(CheckboxOptions().Tooltip("Allows the wallet reward to be collected on any day."));
+    AddWidget(path, "Disable Magic Drops with Chateau Romani", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Cycle.DisableMagicDropsWithChateau")
+        .Options(CheckboxOptions().Tooltip(
+            "When Chateau Romani is active, Magic Jar drops are replaced with Recovery Hearts (which become Rupees "
+            "if health is full)."));
     AddWidget(path, "Unstable", WIDGET_SEPARATOR_TEXT).Options(WidgetOptions().Color(Colors::Orange));
     AddWidget(path, "Disable Save Delay", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Saving.DisableSaveDelay")

--- a/mm/2s2h/Enhancements/Cycle/DisableMagicDropsWithChateau.cpp
+++ b/mm/2s2h/Enhancements/Cycle/DisableMagicDropsWithChateau.cpp
@@ -1,12 +1,13 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/Enhancements/Enhancements.h"
 
 #define CVAR_NAME "gEnhancements.Cycle.DisableMagicDropsWithChateau"
-#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define CVAR CVarGetInteger(CVAR_NAME, DISABLE_MAGIC_DROPS_OFF)
 
 void RegisterDisableMagicDropsWithChateau() {
-    COND_VB_SHOULD(VB_ITEM00_GET_DROP_ID, CVAR, {
+    COND_VB_SHOULD(VB_ITEM00_GET_DROP_ID, CVAR != DISABLE_MAGIC_DROPS_OFF, {
         if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
             return;
         }
@@ -14,7 +15,11 @@ void RegisterDisableMagicDropsWithChateau() {
         s16* dropId = va_arg(args, s16*);
 
         if (*dropId == ITEM00_MAGIC_JAR_SMALL || *dropId == ITEM00_MAGIC_JAR_BIG) {
-            *dropId = ITEM00_RECOVERY_HEART;
+            if (CVAR == DISABLE_MAGIC_DROPS_RECOVERY_HEART) {
+                *dropId = ITEM00_RECOVERY_HEART;
+            } else if (CVAR == DISABLE_MAGIC_DROPS_GREEN_RUPEE) {
+                *dropId = ITEM00_RUPEE_GREEN;
+            }
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cycle/DisableMagicDropsWithChateau.cpp
+++ b/mm/2s2h/Enhancements/Cycle/DisableMagicDropsWithChateau.cpp
@@ -1,0 +1,22 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Cycle.DisableMagicDropsWithChateau"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterDisableMagicDropsWithChateau() {
+    COND_VB_SHOULD(VB_ITEM00_GET_DROP_ID, CVAR, {
+        if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
+            return;
+        }
+
+        s16* dropId = va_arg(args, s16*);
+
+        if (*dropId == ITEM00_MAGIC_JAR_SMALL || *dropId == ITEM00_MAGIC_JAR_BIG) {
+            *dropId = ITEM00_RECOVERY_HEART;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableMagicDropsWithChateau, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -64,6 +64,12 @@ enum GoronRaceDifficultyOptions {
     GORON_RACE_DIFFICULTY_SKIP,
 };
 
+enum DisableMagicDropsOptions {
+    DISABLE_MAGIC_DROPS_OFF,
+    DISABLE_MAGIC_DROPS_RECOVERY_HEART,
+    DISABLE_MAGIC_DROPS_GREEN_RUPEE,
+};
+
 // Old Entry Point
 void InitEnhancements();
 

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1026,6 +1026,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // dropId
+    // ```
+    // #### `args`
+    // - `s16*` (dropId)
+    VB_ITEM00_GET_DROP_ID,
+
+    // #### `result`
+    // ```c
     // !gPlayerFormItemRestrictions[GET_PLAYER_FORM][itemId]
     // ```
     // #### `args`

--- a/mm/src/code/z_en_item00.c
+++ b/mm/src/code/z_en_item00.c
@@ -897,6 +897,8 @@ void EnItem00_DrawHeartPiece(EnItem00* this, PlayState* play) {
 }
 
 s16 func_800A7650(s16 dropId) {
+    GameInteractor_Should(VB_ITEM00_GET_DROP_ID, true, &dropId);
+
     if ((((dropId == ITEM00_BOMBS_A) || (dropId == ITEM00_BOMBS_0) || (dropId == ITEM00_BOMBS_B)) &&
          (INV_CONTENT(ITEM_BOMB) == ITEM_NONE)) ||
         (((dropId == ITEM00_ARROWS_10) || (dropId == ITEM00_ARROWS_30) || (dropId == ITEM00_ARROWS_40) ||


### PR DESCRIPTION
This simply switches out the item drops to be recovery hearts if the player has drank the Chateau. An additional benefit of this, is that if the player is at max health the vanilla logic will switch the recovery heart out for a rupee instead.

This is a potential solution to #1406 

### TODO
- [x] ~Add support for a rupees only option per Jordan's request.~

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5010085884.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5010130353.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5010600927.zip)
<!--- section:artifacts:end -->