### PR TITLE
Limit hover Ocarina dive fix to hovering only

### DIFF
--- a/mm/2s2h/Enhancements/Restorations/OcarinaDive.cpp
+++ b/mm/2s2h/Enhancements/Restorations/OcarinaDive.cpp
@@ -13,19 +13,23 @@ extern PlayState* gPlayState;
  * Console lag frames make that mash humanly possible; the port never lags, so instead we re-queue
  * the promoted cutscene for up to two extra frames, keeping it consumable at realistic mash
  * speeds. Re-queueing goes through the normal request path, so cutscene priority arbitration is
- * unaffected.
+ * unaffected. bgCheckFlags and meleeWeaponState checks to identify hovering
  */
 void RegisterOcarinaDive() {
     COND_HOOK(OnGameStateMainStart, true, []() {
-        static s32 ageFrames = 0;
+        if (gPlayState != NULL) {
+            Player* player = GET_PLAYER(gPlayState);
+            static s32 ageFrames = 0;
 
-        s16 ocarinaCsId = (gPlayState != NULL) ? gPlayState->playerCsIds[PLAYER_CS_ID_ITEM_OCARINA] : CS_ID_NONE;
+            s16 ocarinaCsId = gPlayState->playerCsIds[PLAYER_CS_ID_ITEM_OCARINA];
 
-        if ((ocarinaCsId > CS_ID_NONE) && (CutsceneManager_IsNext(ocarinaCsId) > 0) && (ageFrames < 2)) {
-            ageFrames++;
-            CutsceneManager_Queue(ocarinaCsId);
-        } else {
-            ageFrames = 0;
+            if ((ocarinaCsId > CS_ID_NONE) && (CutsceneManager_IsNext(ocarinaCsId) > 0) && (ageFrames < 2) &&
+                ((player->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) && (player->meleeWeaponState == 1))) {
+                ageFrames++;
+                CutsceneManager_Queue(ocarinaCsId);
+            } else {
+                ageFrames = 0;
+            }
         }
     });
 }


### PR DESCRIPTION
Trying to come up with a scenario where the extended queueing of Ocarina cutscene could cause trouble but it's difficult. If there are such scenarios though, identifying the cause could be hard.

So, might as well try to limit the fix to hovering state only and expand if needed.
The combination of bgCheckFlags having set `GROUND_TOUCH` (and not `GROUND`) and meleeWeaponState being 1 (for ISG) should be sensitive and specific and works with dive:

https://github.com/user-attachments/assets/f9970b12-2408-4165-a064-4276e6d118c9



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8904399935.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8904379582.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8904103220.zip)
<!--- section:artifacts:end -->