### PR TITLE
Time Moves When You Move: fix saving zero time speed

### DIFF
--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -19,11 +19,12 @@ static void UpdateTimeSpeedOffset(PauseContext* pauseCtx) {
     // Time is considered to be moving when any of the following is true:
     // - The player is moving (since that's the basis of this enhancement)
     // - The player is playing the Ocarina (so that Inverted SoT still works properly)
-    // - The player is in a choice dialog (so that Owl Saving doesn't save the wrong time speed)
+    // - The player is choosing whether to save at an Owl Statue (so that it doesn't save the wrong time speed)
     // - The pause menu save prompt is open (so that Pause Save doesn't either)
-    bool timeShouldMove = (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || player->speedXZ != 0.0f ||
-                          Message_GetState(&gPlayState->msgCtx) == TEXT_STATE_CHOICE ||
-                          pauseCtx->state == PAUSE_STATE_SAVEPROMPT;
+    bool timeShouldMove =
+        (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || player->speedXZ != 0.0f ||
+        (Message_GetState(&gPlayState->msgCtx) == TEXT_STATE_CHOICE && gPlayState->msgCtx.currentTextId == 0xC01) ||
+        pauseCtx->state == PAUSE_STATE_SAVEPROMPT;
 
     if (timeShouldMove && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
         gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -21,10 +21,11 @@ static void UpdateTimeSpeedOffset(PauseContext* pauseCtx) {
     // - The player is playing the Ocarina (so that Inverted SoT still works properly)
     // - The player is choosing whether to save at an Owl Statue (so that it doesn't save the wrong time speed)
     // - The pause menu save prompt is open (so that Pause Save doesn't either)
+    // - The Game Over save prompt is open (not reachable right now, but there for future-proofing)
     bool timeShouldMove =
         (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || player->speedXZ != 0.0f ||
         (Message_GetState(&gPlayState->msgCtx) == TEXT_STATE_CHOICE && gPlayState->msgCtx.currentTextId == 0xC01) ||
-        pauseCtx->state == PAUSE_STATE_SAVEPROMPT;
+        pauseCtx->state == PAUSE_STATE_SAVEPROMPT || pauseCtx->state == PAUSE_STATE_GAMEOVER_SAVE_PROMPT;
 
     if (timeShouldMove && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
         gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -88,7 +88,12 @@ static void RegisterTimeMovesWhenYouMove() {
 
     COND_HOOK(OnKaleidoUpdate, CVAR, UpdateTimeSpeedOffset);
 
-    COND_HOOK(OnSaveLoad, CVAR, [](s16) { sStoredTimeOffset = DEFAULT_TIME_OFFSET; });
+    COND_HOOK(OnSaveLoad, CVAR, [](s16) {
+        sStoredTimeOffset = DEFAULT_TIME_OFFSET;
+        if (gSaveContext.save.timeSpeedOffset == -R_TIME_SPEED) {
+            gSaveContext.save.timeSpeedOffset = 0;
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterTimeMovesWhenYouMove, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -89,13 +89,16 @@ static void RegisterTimeMovesWhenYouMove() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) { UpdateTimeSpeedOffset(&gPlayState->pauseCtx); });
 
     COND_HOOK(OnKaleidoUpdate, CVAR, UpdateTimeSpeedOffset);
+}
 
-    COND_HOOK(OnSaveLoad, CVAR, [](s16) {
+static void RegisterTimeSpeedOffsetRepair() {
+    COND_HOOK(OnSaveLoad, true, [](s16) {
         sStoredTimeOffset = DEFAULT_TIME_OFFSET;
-        if (gSaveContext.save.timeSpeedOffset == -R_TIME_SPEED) {
+        if (gSaveContext.save.timeSpeedOffset < -2) {
             gSaveContext.save.timeSpeedOffset = 0;
         }
     });
 }
 
+static RegisterShipInitFunc initFunc_Repair(RegisterTimeSpeedOffsetRepair);
 static RegisterShipInitFunc initFunc(RegisterTimeMovesWhenYouMove, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -13,7 +13,31 @@ extern "C" {
 #define DEFAULT_TIME_OFFSET -12345
 static s32 sStoredTimeOffset = DEFAULT_TIME_OFFSET;
 
-void RegisterTimeMovesWhenYouMove() {
+static void UpdateTimeSpeedOffset(PauseContext* pauseCtx) {
+    Player* player = GET_PLAYER(gPlayState);
+
+    // Time is considered to be moving when any of the following is true:
+    // - The player is moving (since that's the basis of this enhancement)
+    // - The player is playing the Ocarina (so that Inverted SoT still works properly)
+    // - The player is in a choice dialog (so that Owl Saving doesn't save the wrong time speed)
+    // - The pause menu save prompt is open (so that Pause Save doesn't either)
+    bool timeShouldMove = (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || player->speedXZ != 0.0f ||
+                          Message_GetState(&gPlayState->msgCtx) == TEXT_STATE_CHOICE ||
+                          pauseCtx->state == PAUSE_STATE_SAVEPROMPT;
+
+    if (timeShouldMove && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
+        gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;
+        sStoredTimeOffset = DEFAULT_TIME_OFFSET;
+
+        // This is for the section above, lets arrows continue flying after they were fired with time frozen
+        // player->unk_D57 = 4;
+    } else if (!timeShouldMove && sStoredTimeOffset == DEFAULT_TIME_OFFSET) {
+        sStoredTimeOffset = gSaveContext.save.timeSpeedOffset;
+        gSaveContext.save.timeSpeedOffset = -R_TIME_SPEED;
+    }
+}
+
+static void RegisterTimeMovesWhenYouMove() {
     if (!CVAR && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
         gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;
         sStoredTimeOffset = DEFAULT_TIME_OFFSET;
@@ -60,21 +84,11 @@ void RegisterTimeMovesWhenYouMove() {
     //     }
     // });
 
-    COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) {
-        Player* player = GET_PLAYER(gPlayState);
-        bool timeShouldMove = (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || player->speedXZ != 0.0f;
+    COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) { UpdateTimeSpeedOffset(&gPlayState->pauseCtx); });
 
-        if (timeShouldMove && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
-            gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;
-            sStoredTimeOffset = DEFAULT_TIME_OFFSET;
+    COND_HOOK(OnKaleidoUpdate, CVAR, UpdateTimeSpeedOffset);
 
-            // This is for the section above, lets arrows continue flying after they were fired with time frozen
-            // player->unk_D57 = 4;
-        } else if (!timeShouldMove && sStoredTimeOffset == DEFAULT_TIME_OFFSET) {
-            sStoredTimeOffset = gSaveContext.save.timeSpeedOffset;
-            gSaveContext.save.timeSpeedOffset = -R_TIME_SPEED;
-        }
-    });
+    COND_HOOK(OnSaveLoad, CVAR, [](s16) { sStoredTimeOffset = DEFAULT_TIME_OFFSET; });
 }
 
 static RegisterShipInitFunc initFunc(RegisterTimeMovesWhenYouMove, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Saving/AutoSave.cpp
+++ b/mm/2s2h/Enhancements/Saving/AutoSave.cpp
@@ -48,7 +48,7 @@ void HandleAutoSave() {
     }
 
     // Time must be moving for autosave to work. Fixes an issue with Time Moves When You Move.
-    if (gSaveContext.save.timeSpeedOffset == -R_TIME_SPEED) {
+    if (gSaveContext.save.timeSpeedOffset == -R_TIME_SPEED && R_TIME_SPEED != 0) {
         return;
     }
 

--- a/mm/2s2h/Enhancements/Saving/AutoSave.cpp
+++ b/mm/2s2h/Enhancements/Saving/AutoSave.cpp
@@ -47,6 +47,11 @@ void HandleAutoSave() {
         return;
     }
 
+    // Time must be moving for autosave to work. Fixes an issue with Time Moves When You Move.
+    if (gSaveContext.save.timeSpeedOffset == -R_TIME_SPEED) {
+        return;
+    }
+
     // If owl save available to create, do it and reset the interval.
     if (SavingEnhancements_CanSave() && gPlayState->pauseCtx.state == 0) {
 


### PR DESCRIPTION
Fixes #1841

Two main issues contributed to this bug:
1. The enhancement stores a backup time speed variable that is used to restore the correct time speed whenever the player moves around. However, that variable gets set for the first time when a save is loaded and does not get reset if another save is loaded.
2. Owl Saves remember the time speed when they are saved, so if that speed is 0, then that will be the value stored in the backup, meaning that both the backup _and_ the main time speed variables are 0, so time will never start moving.

I fixed the first issue by adding an `OnSaveLoad` hook to reset the backup variable, and I fixed the second issue by adding more conditions to the "is time moving" check. This ensures that the time speed is correct when it gets saved. I also factored Pause Save into this. All that left was Autosave, which I fixed by simply disabling it when the player isn't moving. It'll immediately trigger again when the player starts moving.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8949407251.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8947238577.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8947145135.zip)
<!--- section:artifacts:end -->