### PR TITLE
[Fix] Game crashes when menu engaged when regenerating OTR

### DIFF
--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -539,7 +539,7 @@ void Menu::DrawElement() {
     if (OTRGlobals::Instance->fontStandardLargest == nullptr) {
         return;
     }
-    if (gRegEditor == nullptr) {
+    if (gGameState == nullptr) {
         return;
     }
     for (auto& [reason, info] : disabledMap) {

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -539,6 +539,9 @@ void Menu::DrawElement() {
     if (OTRGlobals::Instance->fontStandardLargest == nullptr) {
         return;
     }
+    if (gRegEditor == nullptr) {
+        return;
+    }
     for (auto& [reason, info] : disabledMap) {
         info.active = info.evaluation(info);
     }


### PR DESCRIPTION
Steps to reproduce:
1. Open Ben Menu
2. Close game
3. Delete `mm.o2r`
4. Start

```
Exception has occurred: W32/0xC0000005
Unhandled exception thrown: read access violation.
gRegEditor was nullptr.
2ship.exe!BenGui::BenMenu::InitElement::__l2::<lambda>(disabledInfo & info) Line 2363 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenGui\BenMenu.cpp:2363)
2ship.exe!`BenGui::BenMenu::InitElement'::`2'::void <lambda>(void)::<lambda_invoker_cdecl>(disabledInfo & info) Line 2363 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenGui\BenMenu.cpp:2363)
2ship.exe!Ship::Menu::DrawElement() Line 543 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenGui\Menu.cpp:543)
2ship.exe!BenGui::BenMenu::DrawElement() Line 2410 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenGui\BenMenu.cpp:2410)
2ship.exe!Ship::Menu::Draw() Line 534 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenGui\Menu.cpp:534)
2ship.exe!BenGui::BenMenu::Draw() Line 2406 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenGui\BenMenu.cpp:2406)
2ship.exe!Ship::Gui::DrawMenu() Line 262 (d:\desk\projs\git\2ship2harkinian\libultraship\src\ship\window\gui\Gui.cpp:262)
2ship.exe!Ship::Gui::StartDraw() Line 323 (d:\desk\projs\git\2ship2harkinian\libultraship\src\ship\window\gui\Gui.cpp:323)
2ship.exe!OTRGlobals::RunExtract(int argc, char * * argv) Line 556 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenPort.cpp:556)
2ship.exe!InitOTR(int argc, char * * argv) Line 960 (d:\desk\projs\git\2ship2harkinian\mm\2s2h\BenPort.cpp:960)
2ship.exe!SDL_main(int argc, char * * argv) Line 76 (d:\desk\projs\git\2ship2harkinian\mm\src\code\main.c:76)
2ship.exe!main_getcmdline() Line 80 (d:\desk\projs\git\2ship2harkinian\build\vcpkg\buildtrees\sdl2\src\se-2.32.10-89f6bbf859.clean\src\main\windows\SDL_windows_main.c:80)
2ship.exe!WinMain(HINSTANCE__ * hInst, HINSTANCE__ * hPrev, char * szCmdLine, int sw) Line 110 (d:\desk\projs\git\2ship2harkinian\build\vcpkg\buildtrees\sdl2\src\se-2.32.10-89f6bbf859.clean\src\main\windows\SDL_windows_main.c:110)
2ship.exe!invoke_main() Line 107 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:107)
2ship.exe!__scrt_common_main_seh() Line 288 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
2ship.exe!__scrt_common_main() Line 331 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331)
2ship.exe!WinMainCRTStartup(void * __formal) Line 17 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_winmain.cpp:17)
kernel32.dll!00007ffcf23c7374() (Unknown Source:0)
ntdll.dll!00007ffcf355cc91() (Unknown Source:0)
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9128866620.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9128849226.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9128689955.zip)
<!--- section:artifacts:end -->