### PR TITLE
Fix interpolation for archery enemies and bubbles

### DIFF
--- a/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
+++ b/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
@@ -273,6 +273,8 @@ struct InterpolateCtx {
     }
 
     void interpolate_branch(Path* old_path, Path* new_path) {
+        const bool self_paired = old_path == new_path;
+
         for (auto& item : new_path->items) {
             Data& new_op = new_path->ops[item.first][item.second];
 
@@ -389,7 +391,9 @@ struct InterpolateCtx {
 
                         case Op::MatrixToMtx: {
                             //*new_replacement(new_op.matrix_to_mtx.dest) = *Matrix_GetCurrent();
-                            if (old_op.matrix_to_mtx.has_adjusted != new_op.matrix_to_mtx.has_adjusted) {
+                            if (self_paired && new_op.matrix_to_mtx.has_adjusted) {
+                                *new_replacement(new_op.matrix_to_mtx.dest) = new_op.matrix_to_mtx.raw;
+                            } else if (old_op.matrix_to_mtx.has_adjusted != new_op.matrix_to_mtx.has_adjusted) {
                                 // has_adjusted toggled between frames (e.g. ActorShadow_Draw's isotropic-shadow
                                 // check flipping as scale.x drifts in and out of equality with scale.z). old.src
                                 // and new.src aren't comparable here: whichever side has has_adjusted=true holds

--- a/mm/src/code/z_effect_soft_sprite.c
+++ b/mm/src/code/z_effect_soft_sprite.c
@@ -22,6 +22,7 @@ void EffectSs_InitInfo(PlayState* play, s32 tableSize) {
 
     for (effectSs = &sEffectSsInfo.table[0]; effectSs < &sEffectSsInfo.table[sEffectSsInfo.tableSize]; effectSs++) {
         EffectSs_Reset(effectSs);
+        effectSs->epoch = 0;
     }
 
     overlay = &gEffectSsOverlayTable[0];
@@ -161,8 +162,11 @@ void EffectSs_Insert(PlayState* play, EffectSs* effectSs) {
 
     if (FrameAdvance_IsEnabled(play) != true) {
         if (EffectSs_FindSlot(effectSs->priority, &index) == 0) {
+            u32 epoch = sEffectSsInfo.table[index].epoch + 1;
+
             sEffectSsInfo.searchStartIndex = index + 1;
             sEffectSsInfo.table[index] = *effectSs;
+            sEffectSsInfo.table[index].epoch = epoch;
         }
     }
 }
@@ -211,6 +215,7 @@ void EffectSs_Spawn(PlayState* play, s32 type, s32 priority, void* initData) {
 
     sEffectSsInfo.table[index].type = type;
     sEffectSsInfo.table[index].priority = priority;
+    sEffectSsInfo.table[index].epoch++;
 
     if (profile->init(play, index, &sEffectSsInfo.table[index], initData) == 0) {
         EffectSs_Reset(&sEffectSsInfo.table[index]);

--- a/mm/src/overlays/actors/ovl_En_Syateki_Dekunuts/z_en_syateki_dekunuts.c
+++ b/mm/src/overlays/actors/ovl_En_Syateki_Dekunuts/z_en_syateki_dekunuts.c
@@ -7,6 +7,7 @@
 #include "z_en_syateki_dekunuts.h"
 #include "overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_LOCK_ON_DISABLED)
 
@@ -483,11 +484,14 @@ void EnSyatekiDekunuts_Draw(Actor* thisx, PlayState* play) {
 
             OPEN_DISPS(play->state.gfxCtx);
 
+            FrameInterpolation_RecordOpenChild(this, i);
+            FrameInterpolation_IgnoreActorMtx();
             Gfx_SetupDL25_Opa(play->state.gfxCtx);
             Matrix_Translate(flowerPos.x, flowerPos.y, flowerPos.z, MTXMODE_NEW);
             Matrix_Scale(0.02f, 0.02f, 0.02f, MTXMODE_APPLY);
             MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx);
             gSPDisplayList(POLY_OPA_DISP++, gDekuScrubFlowerDL);
+            FrameInterpolation_RecordCloseChild();
 
             CLOSE_DISPS(play->state.gfxCtx);
         }


### PR DESCRIPTION
Hopefully these are the last ones. The bubbles was previously fixed but got undone with a decomp update

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9248147356.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9248117718.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9248010225.zip)
<!--- section:artifacts:end -->