### PR TITLE
Fix two small item tracker quirks

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -66,6 +66,18 @@ static bool IsTradeItemObtained(RandoItemId randoItemId) {
     }
 }
 
+// When the file isn't loaded everythin is ocarinas, so we fall back to the first safe item
+u32 GetVanillaItemIdForSlot(u32 slot) {
+    bool isSaveLoaded = gPlayState != NULL && gSaveContext.gameMode == GAMEMODE_NORMAL;
+    u32 vanillaItemId = isSaveLoaded ? gSaveContext.save.saveInfo.inventory.items[slot] : ITEM_NONE;
+
+    if (vanillaItemId == ITEM_NONE || vanillaItemId >= ITEM_RECOVERY_HEART) {
+        vanillaItemId = safeItemsForInventorySlot[slot][0];
+    }
+
+    return vanillaItemId;
+}
+
 TrackerImageObject GetImageObject(TrackerItemType itemType, u32 itemId) {
     bool isSaveLoaded = gPlayState != NULL && gSaveContext.gameMode == GAMEMODE_NORMAL;
     bool itemObtained = false;
@@ -149,10 +161,7 @@ TrackerImageObject GetImageObject(TrackerItemType itemType, u32 itemId) {
         } break;
         case TRACKER_ITEM_SLOT: {
             itemObtained = gSaveContext.save.saveInfo.inventory.items[itemId] != ITEM_NONE;
-            auto vanillaItemId = isSaveLoaded ? gSaveContext.save.saveInfo.inventory.items[itemId] : ITEM_NONE;
-            if (vanillaItemId == ITEM_NONE || vanillaItemId >= ITEM_RECOVERY_HEART) {
-                vanillaItemId = safeItemsForInventorySlot[itemId][0];
-            }
+            auto vanillaItemId = GetVanillaItemIdForSlot(itemId);
 
             trackerImageObject.textureId =
                 std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h
@@ -34,6 +34,7 @@ typedef struct {
 } TrackerGroup;
 
 extern std::vector<TrackerGroup> itemTrackerGroups;
+extern u32 GetVanillaItemIdForSlot(u32 slot);
 extern bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool clickable);
 extern std::string GetItemTrackerItemName(TrackerItemType itemType, u32 itemId);
 

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.cpp
@@ -39,15 +39,22 @@ std::vector<std::pair<TrackerItemType, u32>> GetItemsFromRange(TrackerItemType i
     return items;
 }
 
+// Some items don't have a 1:1 with rando items (eg ITEM_BOMB != RI_BOMBS_5) so we just handle them manually
+static const std::unordered_map<u32, const char*> sVanillaItemNames = {
+    { ITEM_BOMB, "Bombs" },
+    { ITEM_BOMBCHU, "Bombchus" },
+};
+
 std::string GetItemTrackerItemName(TrackerItemType itemType, u32 itemId) {
     switch (itemType) {
         case TRACKER_ITEM_RANDO: {
             return Rando::StaticData::Items[(RandoItemId)itemId].name;
         } break;
         case TRACKER_ITEM_SLOT: {
-            auto vanillaItemId = gSaveContext.save.saveInfo.inventory.items[itemId];
-            if (vanillaItemId == ITEM_NONE) {
-                vanillaItemId = safeItemsForInventorySlot[itemId][0];
+            u32 vanillaItemId = GetVanillaItemIdForSlot(itemId);
+            auto vanillaItemName = sVanillaItemNames.find(vanillaItemId);
+            if (vanillaItemName != sVanillaItemNames.end()) {
+                return vanillaItemName->second;
             }
             RandoItemId randoItemId = Rando::StaticData::GetItemIdFromVanillaItemId(vanillaItemId);
             return Rando::StaticData::Items[randoItemId].name;


### PR DESCRIPTION
everything had "Ocarina of Time" tooltip when save wasn't loaded and Bombs & Bombchu's had "unknown"

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9386405462.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9386364302.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9386329359.zip)
<!--- section:artifacts:end -->