### PR TITLE
Don't skip moon crash CS if player is trying 4th day glitch

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMoonCrash.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMoonCrash.cpp
@@ -18,7 +18,10 @@ extern "C" {
 void RegisterSkipMoonCrash() {
     // Skips initial cutscene in Termina Field where the moon falls, goes straight to clock tower cutscene
     COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, CVAR, {
-        if (gSaveContext.save.cutsceneIndex == 0x0 && gSaveContext.save.entrance == ENTRANCE(TERMINA_FIELD, 12)) {
+        // The respawn flag check here is so that we don't skip if the player is trying to pull off the 4th day
+        // glitch from the telescope
+        if (gSaveContext.save.cutsceneIndex == 0x0 && gSaveContext.save.entrance == ENTRANCE(TERMINA_FIELD, 12) &&
+            gSaveContext.respawnFlag == 0) {
             // This cutscene command would otherwise be run as part of the Fire Wall cutscene that gets skipped.
             // IT MUST BE CALLED HERE IF THAT CUTSCENE IS SKIPPED OR ELSE THE GAME STATE WILL NOT RESET CORRECTLY!
             Sram_ResetSaveFromMoonCrash(&gPlayState->sramCtx);

--- a/mm/2s2h/Enhancements/Graphics/3DSClock.cpp
+++ b/mm/2s2h/Enhancements/Graphics/3DSClock.cpp
@@ -71,7 +71,11 @@ void Draw3DSClock() {
 
             static s32 sFinalHoursIntro = 0;
 
-            sThreeDayClockAlpha = gPlayState->interfaceCtx.bAlpha;
+            if (gPlayState->actorCtx.flags & ACTORCTX_FLAG_TELESCOPE_ON) {
+                sThreeDayClockAlpha = 255;
+            } else {
+                sThreeDayClockAlpha = gPlayState->interfaceCtx.bAlpha;
+            }
 
             s16 posX = 160;
             s16 posY = 210;


### PR DESCRIPTION
So there are 2 different 4th day variants from the telescope, one is much easier(~2 second window) and just puts you back at the astral observ on the 4th day, the other is frame perfect at the end of this window and causes you to be placed on the other side of the great bay fence in termina field.

We can detect this by checking the respawn flag in addition to the CS/Entrance and _not_ skip the cutscene so they can pull off the glitch.

Also mm3d clock was hidden inside telescope unlike normal clock, so fixed that too

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9409591949.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9409407631.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9409398906.zip)
<!--- section:artifacts:end -->