### PR TITLE
Fix pause buffer pause loop with pause save

### DIFF
--- a/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
+++ b/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
@@ -37,14 +37,13 @@ void RegisterPauseBufferInputs() {
 
         // if the input buffer timer is not 0 and the pause state is off, then the player just unpaused
         if (inputBufferTimer != 0 && pauseCtx->state == PAUSE_STATE_OFF) {
-            inputBufferTimer = 0;
-
             // So we need to re-apply the inputs that were pressed during the buffer window
             input->press.button |= pauseInputs;
-        }
 
-        // Reset the timer and stored inputs at the beginning of the unpause process
-        if (pauseCtx->state == PAUSE_STATE_UNPAUSE_SETUP && pauseCtx->itemPageRoll != 160.0f) {
+            inputBufferTimer = 0;
+            pauseInputs = 0;
+        } else if (pauseCtx->state != PAUSE_STATE_UNPAUSE_CLOSE) {
+            // Reset the timer and stored inputs at the beginning of the unpause process
             inputBufferTimer = 0;
             pauseInputs = 0;
         }


### PR DESCRIPTION
Silly bug I ran into when trying the sun's song alien stuff, if you pause buffer a pause input, then exit the menu with the pause save branch it replays the buffer so you get stuck in a pause loop.

this makes it clear the buffer properly

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9458924673.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9458920391.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9458886481.zip)
<!--- section:artifacts:end -->