### PR TITLE
Improvements to file creation UX

### DIFF
--- a/mm/2s2h/Enhancements/Saving/NewFileSetup.cpp
+++ b/mm/2s2h/Enhancements/Saving/NewFileSetup.cpp
@@ -63,7 +63,7 @@ typedef struct {
 #define SETUP_DIVIDER_TEX_INK 204
 #define SETUP_ARROW_MARGIN 10
 #define SETUP_CYCLER_CENTER_X (SETUP_DIVIDER_LEFT + (SETUP_DIVIDER_WIDTH / 2))
-#define SETUP_PRESET_TEXT_WIDTH 160
+#define SETUP_CYCLER_TEXT_WIDTH 160
 #define SETUP_SEED_ICONS 5
 #define SETUP_SEED_ICON_SIZE 16
 #define SETUP_SEED_ICON_GAP 4
@@ -76,6 +76,9 @@ static std::vector<std::string> sPresetNames;
 static std::string sPresetDisplay;
 static s16 sPresetDisplayWidth = 0;
 static s16 sSeedIndex = 0;
+static std::string sInputSeed;
+static std::string sInputSeedDisplay;
+static s16 sInputSeedDisplayWidth = 0;
 static std::unordered_map<std::string, uint32_t> sSeedHashes;
 static SetupLabel sTitle = { gFileSelNewFileTex, 56, 4, 3, 48 };
 static SetupLabel sHeadings[NEW_FILE_SETUP_ROW_MAX] = {
@@ -320,13 +323,18 @@ static void DrawSeedIcons(FileSelectState* fileSelect, uint32_t hash, s16 center
     CLOSE_DISPS(fileSelect->state.gfxCtx);
 }
 
-static void UpdatePresetDisplay(void) {
-    sPresetDisplay = sPresetNames.empty() ? "" : sPresetNames[sPresetIndex];
+static std::string FitToCycler(const std::string& text) {
+    std::string fitted = text;
 
-    while (sPresetDisplay.length() > 4 && TextWidth(sPresetDisplay.c_str()) > SETUP_PRESET_TEXT_WIDTH) {
-        sPresetDisplay = sPresetDisplay.substr(0, sPresetDisplay.length() - 4) + "...";
+    while (fitted.length() > 4 && TextWidth(fitted.c_str()) > SETUP_CYCLER_TEXT_WIDTH) {
+        fitted = fitted.substr(0, fitted.length() - 4) + "...";
     }
 
+    return fitted;
+}
+
+static void UpdatePresetDisplay(void) {
+    sPresetDisplay = FitToCycler(sPresetNames.empty() ? "" : sPresetNames[sPresetIndex]);
     sPresetDisplayWidth = TextWidth(sPresetDisplay.c_str());
 }
 
@@ -342,11 +350,25 @@ static void RefreshPresetList(void) {
     UpdatePresetDisplay();
 }
 
+static void UpdateInputSeedDisplay(void) {
+    std::string inputSeed = Ship_RemoveSpecialCharacters(CVarGetString("gRando.InputSeed", ""));
+
+    if (inputSeed == sInputSeed) {
+        return;
+    }
+
+    sInputSeed = inputSeed;
+    sInputSeedDisplay = FitToCycler(inputSeed);
+    sInputSeedDisplayWidth = TextWidth(sInputSeedDisplay.c_str());
+}
+
 static void RefreshSeedList(void) {
     Rando::Spoiler::RefreshOptions();
     // The list is never empty in practice, but clamping guards against indexing it with -1 if it were
     s32 last = (s32)Rando::Spoiler::spoilerOptions.size() - 1;
     sSeedIndex = (last < 0) ? 0 : (s16)CLAMP(CVarGetInteger("gRando.SpoilerFileIndex", 0), 0, last);
+
+    UpdateInputSeedDisplay();
 }
 
 static void ApplySelection(void) {
@@ -384,6 +406,8 @@ extern "C" void FileSelect_UpdateNewFileSetup(GameState* thisx) {
     s16 presetCount = (s16)sPresetNames.size();
 
     sAlpha = (s16)MIN(sAlpha + 25, 255);
+
+    UpdateInputSeedDisplay();
 
     if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
         Audio_PlaySfx(NA_SE_SY_FSEL_CLOSE);
@@ -474,7 +498,11 @@ extern "C" void FileSelect_DrawNewFileSetup(GameState* thisx) {
         SetValueColor(fileSelect, true, seedRowSelected, alpha);
         DrawArrows(fileSelect, seedY);
 
-        if (sSeedIndex == 0) {
+        if (sSeedIndex == 0 && !sInputSeedDisplay.empty()) {
+            DrawText(fileSelect, sInputSeedDisplay.c_str(), SETUP_CYCLER_CENTER_X - (sInputSeedDisplayWidth / 2),
+                     seedY - 1);
+            SetLabelCombine(fileSelect->state.gfxCtx);
+        } else if (sSeedIndex == 0) {
             DrawLabel(fileSelect, &sGenerateNew, SETUP_CYCLER_CENTER_X - (sGenerateNew.inkWidth / 2), seedY);
         } else if (sSeedIndex < (s16)Rando::Spoiler::spoilerOptions.size()) {
             DrawSeedIcons(fileSelect, SeedHashForSpoiler(Rando::Spoiler::spoilerOptions[sSeedIndex]),
@@ -515,3 +543,10 @@ void RegisterNewFileSetup() {
 }
 
 static RegisterShipInitFunc initFunc(RegisterNewFileSetup, { CVAR_NAME });
+static RegisterShipInitFunc seedListInitFunc(
+    []() {
+        if (gFileSelectState != NULL) {
+            RefreshSeedList();
+        }
+    },
+    { "gRando.SpoilerFile" });

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -314,7 +314,7 @@ static uint32_t checkPoolGeneration = 0;
 void RefreshMetrics() {
     setOfItemsInPool.clear();
     setOfChecksInPool.clear();
-    RandoSaveInfo randoSaveInfo;
+    RandoSaveInfo randoSaveInfo{};
     std::vector<RandoCheckId> checkPool;
     std::vector<RandoItemId> itemPool;
 

--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -46,11 +46,9 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
         try {
             // SpoilerFileIndex == 0 means we're generating a new one
             if (CVarGetInteger("gRando.SpoilerFileIndex", 0) == 0) {
-                bool hadInputSeed = true;
                 std::string inputSeed = Ship_RemoveSpecialCharacters(CVarGetString("gRando.InputSeed", ""));
                 if (inputSeed.empty()) {
                     inputSeed = std::to_string(Ship_Random(0, 1000000));
-                    hadInputSeed = false;
                 }
 
                 SPDLOG_INFO("Generating new randomizer with seed: {}", inputSeed);
@@ -196,9 +194,6 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                     std::string fileName = inputSeed + ".json";
                     Rando::Spoiler::SaveToFile(fileName, spoiler);
 
-                    if (hadInputSeed) {
-                        CVarSetString("gRando.SpoilerFile", fileName.c_str());
-                    }
                     Rando::Spoiler::RefreshOptions();
                 }
 

--- a/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
+++ b/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
@@ -5,6 +5,7 @@
 #include <spdlog/spdlog.h>
 #include "BenPort.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/ShipInit.hpp"
 #include <ship/window/Window.h>
 #include "2s2h/BenGui/Notification.h"
 
@@ -47,6 +48,7 @@ bool Rando::Spoiler::HandleFileDropped(char* filePath) {
         CVarSetString("gRando.SpoilerFile", spoilerFile.c_str());
         // Update the spoiler file options
         Rando::Spoiler::RefreshOptions();
+        ShipInit::Init("gRando.SpoilerFile");
 
         Audio_PlaySfx(NA_SE_SY_QUIZ_CORRECT);
         Notification::Emit({ .message = "Spoiler file loaded" });

--- a/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
+++ b/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
@@ -1,5 +1,6 @@
 #include "Spoiler.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/ShipInit.hpp"
 #include <filesystem>
 #include "BenPort.h"
 
@@ -14,6 +15,7 @@ void Rando::Spoiler::SelectSpoiler(s32 index) {
 
     CVarSetInteger("gRando.SpoilerFileIndex", generateNew ? 0 : index);
     CVarSetString("gRando.SpoilerFile", generateNew ? "" : Rando::Spoiler::spoilerOptions[index].c_str());
+    ShipInit::Init("gRando.SpoilerFile");
 }
 
 // This function refreshes the list of spoiler files in the randomizer folder, this list is used in the Randomizer UI,


### PR DESCRIPTION
This fixes some UX weirdness with the new file creation flow introduced in the battler, 
- When text is entered in the seed input we'll show that to make it clearer to the user they have seed text input
- When a spoiler file is dropped it automatically updates the file creation screen (previously this wouldn't apply unless you went back and then returned to file creation
- No longer "selecting" the spoiler file automatically when using a seed input. This was just causing confusion more than helping

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9715706583.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9715686620.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9715675981.zip)
<!--- section:artifacts:end -->