### PR TITLE
Fix Cremia's Milk Run softlock

### DIFF
--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -20,12 +20,14 @@ static void UpdateTimeSpeedOffset(PauseContext* pauseCtx) {
     // - The player is moving (since that's the basis of this enhancement)
     // - The player is playing the Ocarina (so that Inverted SoT still works properly)
     // - The player is choosing whether to save at an Owl Statue (so that it doesn't save the wrong time speed)
+    // - The Cremia's Milk Run minigame has started (to prevent a softlock)
     // - The pause menu save prompt is open (so that Pause Save doesn't either)
     // - The Game Over save prompt is open (not reachable right now, but there for future-proofing)
     bool timeShouldMove =
         (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || player->speedXZ != 0.0f ||
         (Message_GetState(&gPlayState->msgCtx) == TEXT_STATE_CHOICE && gPlayState->msgCtx.currentTextId == 0xC01) ||
-        pauseCtx->state == PAUSE_STATE_SAVEPROMPT || pauseCtx->state == PAUSE_STATE_GAMEOVER_SAVE_PROMPT;
+        CHECK_WEEKEVENTREG(WEEKEVENTREG_31_80) || pauseCtx->state == PAUSE_STATE_SAVEPROMPT ||
+        pauseCtx->state == PAUSE_STATE_GAMEOVER_SAVE_PROMPT;
 
     if (timeShouldMove && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
         gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;


### PR DESCRIPTION
Fixes #1425

Added a condition to the "Time Moves When You Move" setting to disable it during the minigame.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9742920571.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9742857887.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9742822669.zip)
<!--- section:artifacts:end -->