### PR TITLE
Ensure branch names show up for PR builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,17 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Github Actions checks out a detached HEAD, so check environment for the branch name instead
+if(NOT GIT_BRANCH)
+    if(DEFINED ENV{GITHUB_HEAD_REF} AND NOT "$ENV{GITHUB_HEAD_REF}" STREQUAL "")
+        set(GIT_BRANCH "$ENV{GITHUB_HEAD_REF}")
+    elseif(DEFINED ENV{GITHUB_REF_NAME} AND NOT "$ENV{GITHUB_REF_NAME}" STREQUAL "")
+        set(GIT_BRANCH "$ENV{GITHUB_REF_NAME}")
+    else()
+        set(GIT_BRANCH "detached")
+    endif()
+endif()
+
 set(CMAKE_PROJECT_GIT_BRANCH "${GIT_BRANCH}" CACHE STRING "Git branch" FORCE)
 
 execute_process(
@@ -29,6 +40,15 @@ execute_process(
     OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+# CI builds a PR from an ephemeral merge commit, so report the head commit GitHub shows instead
+if(DEFINED ENV{GITHUB_EVENT_PATH} AND EXISTS "$ENV{GITHUB_EVENT_PATH}")
+    file(READ "$ENV{GITHUB_EVENT_PATH}" GITHUB_EVENT_JSON)
+    string(JSON PR_HEAD_SHA ERROR_VARIABLE PR_HEAD_SHA_ERROR GET "${GITHUB_EVENT_JSON}" "pull_request" "head" "sha")
+    if(PR_HEAD_SHA AND PR_HEAD_SHA_ERROR STREQUAL "NOTFOUND")
+        set(GIT_COMMIT_HASH "${PR_HEAD_SHA}")
+    endif()
+endif()
 
 # Get only the first 7 characters of the hash
 string(SUBSTRING "${GIT_COMMIT_HASH}" 0 7 SHORT_COMMIT_HASH)

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -441,7 +441,7 @@ void BenMenu::AddSettings() {
         ImGui::BeginChild("about");
         ImGui::PushStyleColor(ImGuiCol_Text, ColorValues.at(Colors::Gray));
         if (gGitCommitTag[0] == 0) {
-            ImGui::Text("%s | %s", (char*)gGitBranch, (char*)gGitCommitHash);
+            ImGui::Text("%s | %s | %s", (char*)gBuildVersion, (char*)gGitBranch, (char*)gGitCommitHash);
         } else {
             ImGui::Text("%s", (char*)gBuildVersion);
         }

--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -52,6 +52,9 @@ void ConsoleLogo_PrintBuildInfo(ConsoleLogoState* this) {
     bool showGitInfo = gGitCommitTag[0] == 0;
 
     if (showGitInfo) {
+        GfxPrint_SetPos(&printer, 1, 23);
+        GfxPrint_Printf(&printer, "%s", gBuildVersion);
+
         GfxPrint_SetPos(&printer, 1, 24);
         GfxPrint_Printf(&printer, "Git Branch: %s", gGitBranch);
 


### PR DESCRIPTION
Long standing annoyance of mine, no one can easily see/prove what version/branch they are on when using PR builds. This makes it to where on PR builds and locally it displays the cmake value (Battler Bravo) + branch (from git or from github in CI) + commit sha (from git)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9831314969.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9831288754.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9831102062.zip)
<!--- section:artifacts:end -->