### PR TITLE
Save Persistent Bunny Hood state in file info

### DIFF
--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -123,6 +123,7 @@ inline void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
     j = json{
         { "dpadEquips", shipSaveInfo.dpadEquips },
         { "pauseSaveEntrance", shipSaveInfo.pauseSaveEntrance },
+        { "persistentBunnyHood", shipSaveInfo.persistentBunnyHood },
         { "saveType", shipSaveInfo.saveType },
         { "fileCreatedAt", shipSaveInfo.fileCreatedAt },
         { "fileCompletedAt", shipSaveInfo.fileCompletedAt },
@@ -139,6 +140,7 @@ inline void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
 inline void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     j.at("dpadEquips").get_to(shipSaveInfo.dpadEquips);
     j.at("pauseSaveEntrance").get_to(shipSaveInfo.pauseSaveEntrance);
+    j.at("persistentBunnyHood").get_to(shipSaveInfo.persistentBunnyHood);
     j.at("saveType").get_to(shipSaveInfo.saveType);
     j.at("fileCreatedAt").get_to(shipSaveInfo.fileCreatedAt);
     j.at("fileCompletedAt").get_to(shipSaveInfo.fileCompletedAt);

--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -16,7 +16,7 @@ extern const char* D_801C0B20[28];
 #define CVAR_NAME "gEnhancements.Masks.PersistentBunnyHood.Enabled"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-void UpdatePersistentMasksState() {
+static void UpdatePersistentMasksState() {
     static Vtx* persistentMasksVtx;
     static HOOK_ID beforePageDrawHook = 0;
     static HOOK_ID onPlayerPostLimbDrawHook = 0;
@@ -142,7 +142,7 @@ void UpdatePersistentMasksState() {
         });
 }
 
-void RegisterPersistentMasks() {
+static void RegisterPersistentMasks() {
     UpdatePersistentMasksState();
 
     // Easiest way to handle things like loading into a different file, debug warping, etc.

--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -14,9 +14,7 @@ extern const char* D_801C0B20[28];
 }
 
 #define CVAR_NAME "gEnhancements.Masks.PersistentBunnyHood.Enabled"
-#define STATE_CVAR_NAME "gEnhancements.Masks.PersistentBunnyHood.State"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
-#define STATE_CVAR CVarGetInteger(STATE_CVAR_NAME, 0)
 
 void UpdatePersistentMasksState() {
     static Vtx* persistentMasksVtx;
@@ -26,14 +24,14 @@ void UpdatePersistentMasksState() {
     GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnPlayerPostLimbDraw>(onPlayerPostLimbDrawHook);
 
     if (!CVAR) {
-        CVarClear(STATE_CVAR_NAME);
+        gSaveContext.save.shipSaveInfo.persistentBunnyHood = false;
         return;
     }
 
     // If the mask is equipped, unequip it
     if (gSaveContext.save.equippedMask == PLAYER_MASK_BUNNY) {
         gSaveContext.save.equippedMask = PLAYER_MASK_NONE;
-        CVarSetInteger(STATE_CVAR_NAME, 1);
+        gSaveContext.save.shipSaveInfo.persistentBunnyHood = true;
 
         if (gPlayState != NULL) {
             Player* player = GET_PLAYER(gPlayState);
@@ -44,13 +42,13 @@ void UpdatePersistentMasksState() {
 
     // If they don't have the mask, clear the state
     if (INV_CONTENT(ITEM_MASK_BUNNY) != ITEM_MASK_BUNNY) {
-        CVarClear(STATE_CVAR_NAME);
+        gSaveContext.save.shipSaveInfo.persistentBunnyHood = false;
     }
 
     // This hook draws the mask on the players head when it's active and they aren't in first person
     onPlayerPostLimbDrawHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnPlayerPostLimbDraw>(
         PLAYER_LIMB_HEAD, [](Player* player, s32 limbIndex) {
-            if (!STATE_CVAR) {
+            if (!gSaveContext.save.shipSaveInfo.persistentBunnyHood) {
                 return;
             }
 
@@ -133,7 +131,7 @@ void UpdatePersistentMasksState() {
                 persistentMasksVtx[i + 0].v.cn[3] = persistentMasksVtx[i + 1].v.cn[3] =
                     persistentMasksVtx[i + 2].v.cn[3] = persistentMasksVtx[i + 3].v.cn[3] = pauseCtx->alpha;
 
-                if (STATE_CVAR) {
+                if (gSaveContext.save.shipSaveInfo.persistentBunnyHood) {
                     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 100, 200, 255, 255);
                     gSPVertex(POLY_OPA_DISP++, (uintptr_t)persistentMasksVtx, 4, 0);
                     POLY_OPA_DISP = Gfx_DrawTexQuadIA8(POLY_OPA_DISP, (TexturePtr)gEquippedItemOutlineTex, 32, 32, 0);
@@ -156,7 +154,7 @@ void RegisterPersistentMasks() {
 
         // But don't speed up if the player is non-human and controller input is being overriden for cutscenes/minigames
         // or if player is Kafei
-        if (player && STATE_CVAR && player->actor.id == ACTOR_PLAYER &&
+        if (player && gSaveContext.save.shipSaveInfo.persistentBunnyHood && player->actor.id == ACTOR_PLAYER &&
             (GET_PLAYER_FORM == PLAYER_FORM_HUMAN || gPlayState->actorCtx.isOverrideInputOn == 0)) {
             *should = true;
         }
@@ -178,8 +176,8 @@ void RegisterPersistentMasks() {
         if (*maskId == PLAYER_MASK_BUNNY) {
             *should = false;
 
-            CVarSetInteger(STATE_CVAR_NAME, !STATE_CVAR);
-            if (STATE_CVAR) {
+            gSaveContext.save.shipSaveInfo.persistentBunnyHood = !gSaveContext.save.shipSaveInfo.persistentBunnyHood;
+            if (gSaveContext.save.shipSaveInfo.persistentBunnyHood) {
                 func_8082E1F0(player, NA_SE_PL_CHANGE_ARMS);
             } else {
                 func_8082E1F0(player, NA_SE_PL_TAKE_OUT_SHIELD);
@@ -194,7 +192,7 @@ void RegisterPersistentMasks() {
         va_arg(args, s32); // slot
         va_arg(args, s32); // isDpad
         va_arg(args, s32); // pageIndex
-        if (*itemId == ITEM_MASK_BUNNY && STATE_CVAR) {
+        if (*itemId == ITEM_MASK_BUNNY && gSaveContext.save.shipSaveInfo.persistentBunnyHood) {
             *should = false;
         }
     });
@@ -212,8 +210,8 @@ void RegisterPersistentMasks() {
         ItemId itemId = (ItemId)*va_arg(args, u16*);
         if (itemId == ITEM_MASK_BUNNY) {
             *should = false;
-            CVarSetInteger(STATE_CVAR_NAME, !STATE_CVAR);
-            if (STATE_CVAR) {
+            gSaveContext.save.shipSaveInfo.persistentBunnyHood = !gSaveContext.save.shipSaveInfo.persistentBunnyHood;
+            if (gSaveContext.save.shipSaveInfo.persistentBunnyHood) {
                 Audio_PlaySfx(NA_SE_SY_CAMERA_ZOOM_DOWN);
             } else {
                 Audio_PlaySfx(NA_SE_SY_CAMERA_ZOOM_UP);
@@ -227,7 +225,7 @@ void RegisterPersistentMasks() {
         Player* player = GET_PLAYER(gPlayState);
         PlayerItemAction playerItemAction = (PlayerItemAction)va_arg(args, int);
 
-        if (player && STATE_CVAR && playerItemAction == PLAYER_IA_MASK_BUNNY) {
+        if (player && gSaveContext.save.shipSaveInfo.persistentBunnyHood && playerItemAction == PLAYER_IA_MASK_BUNNY) {
             *should = true;
         }
     });

--- a/mm/2s2h/SaveManager/Migrations/8.cpp
+++ b/mm/2s2h/SaveManager/Migrations/8.cpp
@@ -1,0 +1,9 @@
+#include "2s2h/SaveManager/SaveManager.h"
+#include "z64.h"
+
+// Add Persistent Bunny Hood state to saves
+void SaveManager_Migration_8(nlohmann::json& j) {
+    if (!j["save"]["shipSaveInfo"].contains("persistentBunnyHood")) {
+        j["save"]["shipSaveInfo"]["persistentBunnyHood"] = 0;
+    }
+}

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -42,7 +42,7 @@ const std::filesystem::path savesFolderPath(Ship::Context::GetPathRelativeToAppD
 // - Create the migration file in the Migrations folder with the name `{CURRENT_SAVE_VERSION}.cpp`
 // - Add the migration function definition below and add it to the `migrations` map with the key being the previous
 // version
-const uint32_t CURRENT_SAVE_VERSION = 7;
+const uint32_t CURRENT_SAVE_VERSION = 8;
 
 void SaveManager_Migration_1(nlohmann::json& j);
 void SaveManager_Migration_2(nlohmann::json& j);
@@ -51,6 +51,7 @@ void SaveManager_Migration_4(nlohmann::json& j);
 void SaveManager_Migration_5(nlohmann::json& j);
 void SaveManager_Migration_6(nlohmann::json& j);
 void SaveManager_Migration_7(nlohmann::json& j);
+void SaveManager_Migration_8(nlohmann::json& j);
 
 const std::unordered_map<uint32_t, std::function<void(nlohmann::json&)>> migrations = {
     // Pre-1.0.0 Migrations, deprecated
@@ -62,6 +63,7 @@ const std::unordered_map<uint32_t, std::function<void(nlohmann::json&)>> migrati
     { 4, SaveManager_Migration_5 },
     { 5, SaveManager_Migration_6 },
     { 6, SaveManager_Migration_7 },
+    { 7, SaveManager_Migration_8 },
 };
 
 int SaveManager_MigrateSave(nlohmann::json& j) {

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -405,6 +405,7 @@ typedef struct ShipSaveInfo {
     char commitHash[8];
     RandoSaveInfo rando;
     u8 bombArrowsEquipped;
+    u8 persistentBunnyHood;
 } ShipSaveInfo;
 // #endregion
 

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1015,6 +1015,7 @@ void Sram_InitNewSave(void) {
     memcpy(&gSaveContext.save.shipSaveInfo.commitHash, &gGitCommitHash,
            sizeof(gSaveContext.save.shipSaveInfo.commitHash));
     gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
+    gSaveContext.save.shipSaveInfo.persistentBunnyHood = false;
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
@@ -1247,6 +1248,7 @@ void Sram_InitDebugSave(void) {
     memcpy(&gSaveContext.save.shipSaveInfo.commitHash, &gGitCommitHash,
            sizeof(gSaveContext.save.shipSaveInfo.commitHash));
     gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
+    gSaveContext.save.shipSaveInfo.persistentBunnyHood = false;
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;


### PR DESCRIPTION
Fixes #836

<img width="1920" height="1080" alt="2026-09-02" src="https://github.com/user-attachments/assets/991e98d9-6e21-4646-9cc3-85aa4fbbacd3" />

By the way, I know someone is going to ask: "What if you reload the save with Persistent Bunny Hood turned off?" Well, I assume you'd expect that Link just wouldn't be wearing the Bunny Hood anymore when you load the save, and indeed, that's exactly what happens.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9866829827.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9866824553.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9866746946.zip)
<!--- section:artifacts:end -->