### PR TITLE
Reordered if checks to prevent null pointer reference and crash

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/mm/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -397,7 +397,7 @@ void EnAttackNiw_Update(Actor* thisx, PlayState* play) {
 
         if (this->actor.xyzDistToPlayerSq < SQ(viewOffset)) {
             parent = (EnNiw*)this->actor.parent;
-            if ((this->actor.parent->update != NULL) && (this->actor.parent != NULL) && (parent != NULL) &&
+            if ((this->actor.parent != NULL) && (this->actor.parent->update != NULL) && (parent != NULL) &&
                 (parent->unkAttackNiwTimer == 0) && (player->invincibilityTimer == 0)) {
                 // this updates some player values based on what we pass, need player decomp to know what this is doing
                 func_800B8D50(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);


### PR DESCRIPTION
Ensures the If statement checks that the actor.parent is !NULL before checking if the parent has an update. Prevents a null pointer reference and a crash.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9989544454.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9989397851.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9989384639.zip)
<!--- section:artifacts:end -->