### PR TITLE
[Rando] Add SoT reset NPC to clock tower rooftop

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnJs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJs.cpp
@@ -150,7 +150,7 @@ void OverrideMainJsText(u16* textId, bool* loadFromMessageTable) {
     }
 }
 
-void EnJs_PostLimbDraw_NoMask(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, Actor* thisx) {
+void EnJs_PostLimbDraw_LinkMask(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, Actor* thisx) {
     if (limbIndex == MOONCHILD_LIMB_HEAD) {
         Matrix_MultVec3f(&D_8096AC30, &thisx->focus.pos);
         OPEN_DISPS(play->state.gfxCtx);
@@ -162,12 +162,12 @@ void EnJs_PostLimbDraw_NoMask(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s
     }
 }
 
-void EnJs_Draw_NoMask(Actor* thisx, PlayState* play) {
+void EnJs_Draw_LinkMask(Actor* thisx, PlayState* play) {
     EnJs* enJs = (EnJs*)thisx;
 
     Gfx_SetupDL25_Opa(play->state.gfxCtx);
     SkelAnime_DrawFlexOpa(play, enJs->skelAnime.skeleton, enJs->skelAnime.jointTable, enJs->skelAnime.dListCount, NULL,
-                          EnJs_PostLimbDraw_NoMask, &enJs->actor);
+                          EnJs_PostLimbDraw_LinkMask, &enJs->actor);
 }
 
 void EnJs_ResetTime(EnJs* enJs, PlayState* play) {
@@ -192,6 +192,13 @@ void EnJs_PromptForDialog(EnJs* enJs, PlayState* play) {
     } else if (func_80968DD0(enJs, play)) {
         Actor_OfferTalk(&enJs->actor, play, 120.0f);
     }
+}
+
+void EnJs_SpawnResetNpc(float rotY) {
+    u32 params = 8;
+    Actor* actor = Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_JS, -150, 40, 50, 0, rotY, 0, params);
+    actor->draw = EnJs_Draw_LinkMask;
+    ((EnJs*)actor)->actionFunc = EnJs_PromptForDialog;
 }
 
 void Rando::ActorBehavior::InitEnJsBehavior() {
@@ -225,14 +232,11 @@ void Rando::ActorBehavior::InitEnJsBehavior() {
         }
     });
 
-    COND_ID_HOOK(OnSceneInit, SCENE_SOUGEN, IS_RANDO, [](s8 sceneId, s8 spawnNum) {
-        u32 params = 8;
-        Actor* actor = Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_JS, -150, 40, 50, 0, -15000, 0, params);
-        actor->draw = EnJs_Draw_NoMask;
-    });
+    COND_ID_HOOK(OnSceneInit, SCENE_SOUGEN, IS_RANDO, [](s8 sceneId, s8 spawnNum) { EnJs_SpawnResetNpc(-15000); });
+    COND_ID_HOOK(OnSceneInit, SCENE_OKUJOU, IS_RANDO, [](s8 sceneId, s8 spawnNum) { EnJs_SpawnResetNpc(7000); });
 
     COND_ID_HOOK(OnActorInit, ACTOR_EN_JS, IS_RANDO, [](Actor* actor) {
-        if (actor->draw == EnJs_Draw_NoMask) {
+        if (actor->draw == EnJs_Draw_LinkMask) {
             ((EnJs*)actor)->actionFunc = EnJs_PromptForDialog;
             actor->world.pos.y = 0;
         }


### PR DESCRIPTION
Takes #1798 and also adds the NPC to the clock tower rooftop, as players without the ability to play SoT would have to just wait for the countdown to elapse. Also renamed some draw funcs

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/10153578471.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/10153456603.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/10153071091.zip)
<!--- section:artifacts:end -->